### PR TITLE
hotfix: publish material-ui@0.1.5

### DIFF
--- a/extensions/iceworks-component-builder/package.json
+++ b/extensions/iceworks-component-builder/package.json
@@ -3,7 +3,7 @@
   "displayName": "Iceworks Component Builder",
   "description": "Build Component UI by low-code way",
   "publisher": "iceworks-team",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "engines": {
     "vscode": "^1.41.0"
   },

--- a/extensions/iceworks-component-builder/web/package.json
+++ b/extensions/iceworks-component-builder/web/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@alifd/next": "~1.19.2",
     "@alifd/theme-iceworks-dark": "^1.1.0",
-    "@iceworks/material-ui": "^0.1.3",
+    "@iceworks/material-ui": "^0.1.5",
     "@iceworks/vscode-webview": "^0.1.1",
     "moment": "^2.24.0",
     "react": "^16.8.0",

--- a/extensions/iceworks-page-builder/web/package.json
+++ b/extensions/iceworks-page-builder/web/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@alifd/next": "~1.19.2",
     "@alifd/theme-iceworks-dark": "^1.1.0",
-    "@iceworks/material-ui": "^0.1.3",
+    "@iceworks/material-ui": "^0.1.5",
     "@iceworks/vscode-webview": "^0.1.1",
     "moment": "^2.24.0",
     "react": "^16.8.0",

--- a/packages/material-ui/package.json
+++ b/packages/material-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iceworks/material-ui",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Material panel for display and select materials.",
   "files": [
     "demo/",
@@ -54,6 +54,6 @@
     "access": "public"
   },
   "license": "MIT",
-  "homepage": "https://unpkg.com/@iceworks/material-ui@0.1.3/build/index.html",
+  "homepage": "https://unpkg.com/@iceworks/material-ui@0.1.5/build/index.html",
   "gitHead": "fc5b35f95ab4cc24898845916acf598c2f34d576"
 }


### PR DESCRIPTION
material-ui 在 CI 中构建出来的内容有误，具体原因待排查。

当前先手动发布 `@iceworks/material-ui`，然后再手动发布相关对其有依赖的插件。