### PR TITLE
fix: change extensions version for publishing extensions local

### DIFF
--- a/extensions/iceworks-app/CHANGELOG.md
+++ b/extensions/iceworks-app/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## 0.1.30
+## 0.1.31
 
 - Fix: Not show the welcome when the current workspace is not React or Rax App.
 

--- a/extensions/iceworks-app/package.json
+++ b/extensions/iceworks-app/package.json
@@ -3,7 +3,7 @@
   "displayName": "Iceworks App",
   "description": "Universal Application Development Extension.",
   "publisher": "iceworks-team",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "engines": {
     "vscode": "^1.41.0"
   },

--- a/extensions/iceworks-project-creator/CHANGELOG.md
+++ b/extensions/iceworks-project-creator/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## 0.1.4
+## 0.1.5
 - style: better styles of the webview
 - feat: Support select GitLab group and check the GitLab Repo name
  

--- a/extensions/iceworks-project-creator/package.json
+++ b/extensions/iceworks-project-creator/package.json
@@ -3,7 +3,7 @@
   "displayName": "Iceworks Project Creator",
   "description": "Quick create a Universal Application project(React/Rax/Vue, etc).",
   "publisher": "iceworks-team",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "engines": {
     "vscode": "^1.41.0"
   },


### PR DESCRIPTION
背景：
线上发布插件（iceworks-app & iceworks-project-creator）不成功，需要本地发布插件至插件市场

解决：
更改对应的插件的版本号