### PR TITLE
Feat add style completion

### DIFF
--- a/extensions/iceworks-style-helper/CHANGELOG.md
+++ b/extensions/iceworks-style-helper/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 0.2.0
+
+Add `class` name completions.
+
+
 ## 0.1.0
 
 Initial release

--- a/extensions/iceworks-style-helper/README.en.md
+++ b/extensions/iceworks-style-helper/README.en.md
@@ -10,6 +10,10 @@ When editing the 'style' attribute of a component in a JSX file, an automatic co
 
 ![demo](https://img.alicdn.com/tfs/TB1oyRBF1H2gK0jSZFEXXcqMpXa-1000-586.gif)
 
+When editing the 'class' name of a CSS, LESS or SASS file, an automatic completion reminder will be given:
+
+![demo](https://img.alicdn.com/tfs/TB1l_zMFhD1gK0jSZFKXXcJrVXa-500-355.gif)
+
 ## More
 
 See the [Iceworks Pack](https://marketplace.visualstudio.com/items?itemName=iceworks-team.iceworks) to know more features.

--- a/extensions/iceworks-style-helper/README.en.md
+++ b/extensions/iceworks-style-helper/README.en.md
@@ -14,6 +14,12 @@ When editing the 'class' name of a CSS, LESS or SASS file, an automatic completi
 
 ![demo](https://img.alicdn.com/tfs/TB1l_zMFhD1gK0jSZFKXXcJrVXa-500-355.gif)
 
+Automatic completion When editing the 'style' name of a component in a JSX file, Use `cmd + click`  (Windows: `ctrl + click`) jump to the identifier under the cursor.
+
+![demo](https://img.alicdn.com/tfs/TB1l_zMFhD1gK0jSZFKXXcJrVXa-500-355.gif)
+
+![demo](https://img.alicdn.com/tfs/TB1UDGht.Y1gK0jSZFMXXaWcVXa-1468-906.gif)
+
 ## More
 
 See the [Iceworks Pack](https://marketplace.visualstudio.com/items?itemName=iceworks-team.iceworks) to know more features.

--- a/extensions/iceworks-style-helper/README.en.md
+++ b/extensions/iceworks-style-helper/README.en.md
@@ -16,7 +16,7 @@ When editing the 'class' name of a CSS, LESS or SASS file, an automatic completi
 
 Automatic completion When editing the 'style' name of a component in a JSX file, Use `cmd + click`  (Windows: `ctrl + click`) jump to the identifier under the cursor.
 
-![demo](https://img.alicdn.com/tfs/TB1l_zMFhD1gK0jSZFKXXcJrVXa-500-355.gif)
+![demo](https://img.alicdn.com/tfs/TB1pb1ltYY1gK0jSZTEXXXDQVXa-1468-906.gif)
 
 ![demo](https://img.alicdn.com/tfs/TB1UDGht.Y1gK0jSZFMXXaWcVXa-1468-906.gif)
 

--- a/extensions/iceworks-style-helper/README.md
+++ b/extensions/iceworks-style-helper/README.md
@@ -10,6 +10,10 @@
 
 ![使用示例](https://img.alicdn.com/tfs/TB1oyRBF1H2gK0jSZFEXXcqMpXa-1000-586.gif)
 
+在 CSS、LESS、SASS 文件中编辑 `class` 名称时给予自动补全提醒：
+
+![使用示例](https://img.alicdn.com/tfs/TB1l_zMFhD1gK0jSZFKXXcJrVXa-500-355.gif)
+
 ## 更多
 
 访问 [Iceworks Pack](https://marketplace.visualstudio.com/items?itemName=iceworks-team.iceworks) 了解更多 Iceworks 相关功能。

--- a/extensions/iceworks-style-helper/README.md
+++ b/extensions/iceworks-style-helper/README.md
@@ -14,6 +14,12 @@
 
 ![使用示例](https://img.alicdn.com/tfs/TB1l_zMFhD1gK0jSZFKXXcJrVXa-500-355.gif)
 
+在 JSX 文件中编辑组件的样式名时给予补全提醒并可通过 `cmd + 点击`（ Windows: `ctrl + 点击` ）跳转：
+
+![使用示例](https://img.alicdn.com/tfs/TB1l_zMFhD1gK0jSZFKXXcJrVXa-500-355.gif)
+
+![使用示例](https://img.alicdn.com/tfs/TB1UDGht.Y1gK0jSZFMXXaWcVXa-1468-906.gif)
+
 ## 更多
 
 访问 [Iceworks Pack](https://marketplace.visualstudio.com/items?itemName=iceworks-team.iceworks) 了解更多 Iceworks 相关功能。

--- a/extensions/iceworks-style-helper/README.md
+++ b/extensions/iceworks-style-helper/README.md
@@ -16,7 +16,7 @@
 
 在 JSX 文件中编辑组件的样式名时给予补全提醒并可通过 `cmd + 点击`（ Windows: `ctrl + 点击` ）跳转：
 
-![使用示例](https://img.alicdn.com/tfs/TB1l_zMFhD1gK0jSZFKXXcJrVXa-500-355.gif)
+![使用示例](https://img.alicdn.com/tfs/TB1pb1ltYY1gK0jSZTEXXXDQVXa-1468-906.gif)
 
 ![使用示例](https://img.alicdn.com/tfs/TB1UDGht.Y1gK0jSZFMXXaWcVXa-1468-906.gif)
 

--- a/extensions/iceworks-style-helper/package.json
+++ b/extensions/iceworks-style-helper/package.json
@@ -3,7 +3,7 @@
   "displayName": "Iceworks Style Helper",
   "description": "Easily write styles in JSX.",
   "publisher": "iceworks-team",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "engines": {
     "vscode": "^1.41.0"
   },
@@ -22,7 +22,10 @@
     "onLanguage:javascript",
     "onLanguage:javascriptreact",
     "onLanguage:typescript",
-    "onLanguage:typescriptreact"
+    "onLanguage:typescriptreact",
+		"onLanguage:css",
+		"onLanguage:less",
+		"onLanguage:sass"
   ],
   "repository": {
     "type": "git",

--- a/extensions/iceworks-style-helper/package.json
+++ b/extensions/iceworks-style-helper/package.json
@@ -23,9 +23,9 @@
     "onLanguage:javascriptreact",
     "onLanguage:typescript",
     "onLanguage:typescriptreact",
-		"onLanguage:css",
-		"onLanguage:less",
-		"onLanguage:sass"
+    "onLanguage:css",
+    "onLanguage:less",
+    "onLanguage:sass"
   ],
   "repository": {
     "type": "git",
@@ -43,6 +43,9 @@
     "typescript": "^3.6.4"
   },
   "dependencies": {
+    "@babel/parser": "^7.10.3",
+    "@babel/traverse": "^7.10.3",
+    "css": "^2.2.4",
     "vscode-web-custom-data": "^0.1.4"
   }
 }

--- a/extensions/iceworks-style-helper/src/cssClassAutoCompete/index.ts
+++ b/extensions/iceworks-style-helper/src/cssClassAutoCompete/index.ts
@@ -1,0 +1,88 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { getFocusCodeInfo } from '../getFocusCodeInfo';
+
+function unique(arr: string[]) {
+  return Array.from(new Set(arr));
+}
+
+function provideCompletionItems(document: vscode.TextDocument, position: vscode.Position): vscode.CompletionItem[] {
+  const completions: vscode.CompletionItem[] = [];
+  const { word, directory } = getFocusCodeInfo(document, position);
+
+  // Completion items for className writing.
+  if (word !== '.') {
+    return completions;
+  }
+
+  let classNames: string[] = [];
+  // Read classNames from the file which is in the same directory.
+  fs.readdirSync(directory).forEach((file) => {
+    if (path.extname(file) === '.jsx' || path.extname(file) === '.tsx') {
+      const filePath = `${directory}/${file}`;
+      // Add className="xxx" and  style={styles.xxx}
+      classNames = classNames.concat(getClassNames(filePath), getCSSModuleKeys(filePath));
+    }
+  });
+  
+  return unique(classNames).map(
+    className =>
+      new vscode.CompletionItem(
+        `.${className}`,
+        vscode.CompletionItemKind.Text
+      )
+  );
+}
+
+// Process className="xxx"
+function getClassNames(filePath: string): string[] {
+  const code = fs.readFileSync(filePath, 'utf8');
+  const reg = new RegExp('className="([\\w- ]+)"', 'g');
+
+  let classNames: string[] = [];
+  let matched: RegExpExecArray | null;;
+
+  // eslint-disable-next-line
+  while ((matched = reg.exec(code)) !== null) {
+    const className = matched[1];
+    // Process className="test1 test2"
+    if (className.includes(' ')) {
+      classNames = classNames.concat(className.split(' '));
+    } else {
+      classNames.push(className);
+    }
+  }
+  return classNames;
+}
+
+// Process style={styles.xxx}
+function getCSSModuleKeys(filePath: string): string[] {
+  const code = fs.readFileSync(filePath, 'utf8');
+  const reg = new RegExp('style=\\{styles\\.([\\w\\.]+)\\}', 'g');
+
+  const CSSModuleKeys: string[] = [];
+  let matched: RegExpExecArray | null;
+
+  // eslint-disable-next-line
+  while ((matched = reg.exec(code)) !== null) {
+    CSSModuleKeys.push(matched[1]);
+  }
+  return CSSModuleKeys;
+}
+
+// Set completion
+export default function cssClassAutoCompete(context: vscode.ExtensionContext): void {
+  // Register completionItem provider
+  context.subscriptions.push(
+    vscode.languages.registerCompletionItemProvider(
+      [
+        { scheme: 'file', language: 'css' },
+        { scheme: 'file', language: 'less' },
+        { scheme: 'file', language: 'sass' }
+      ],
+      { provideCompletionItems },
+      '.'
+    )
+  );
+};

--- a/extensions/iceworks-style-helper/src/index.ts
+++ b/extensions/iceworks-style-helper/src/index.ts
@@ -1,7 +1,10 @@
 import * as vscode from 'vscode';
+import cssClassAutoCompete from './cssClassAutoCompete';
 import inlineStyleAutoComplete from './inlineStyleAutoComplete';
 
+
 function activate(context: vscode.ExtensionContext) {
+  cssClassAutoCompete(context);
   inlineStyleAutoComplete(context);
 };
 

--- a/extensions/iceworks-style-helper/src/index.ts
+++ b/extensions/iceworks-style-helper/src/index.ts
@@ -1,11 +1,13 @@
 import * as vscode from 'vscode';
 import cssClassAutoCompete from './cssClassAutoCompete';
 import inlineStyleAutoComplete from './inlineStyleAutoComplete';
+import styleInfoViewer from './styleInfoViewer';
 
 
 function activate(context: vscode.ExtensionContext) {
   cssClassAutoCompete(context);
   inlineStyleAutoComplete(context);
+  styleInfoViewer(context);
 };
 
 exports.activate = activate;

--- a/extensions/iceworks-style-helper/src/inlineStyleAutoComplete/index.ts
+++ b/extensions/iceworks-style-helper/src/inlineStyleAutoComplete/index.ts
@@ -102,7 +102,6 @@ function provideCompletionItems(document: vscode.TextDocument, position: vscode.
       })
     }
   }
-  console.log(completions);
   return completions;
 }
 

--- a/extensions/iceworks-style-helper/src/styleInfoViewer/findStyle.ts
+++ b/extensions/iceworks-style-helper/src/styleInfoViewer/findStyle.ts
@@ -1,0 +1,48 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import css from 'css';
+import { IStyleDependency } from './findStyleDependencies';
+
+// https://www.npmjs.com/package/css
+export interface IStylePosition {
+  start: {
+    line: number;
+    column: number;
+  };
+  end: {
+    line: number;
+    column: number;
+  };
+}
+
+export interface IStyle {
+  type: string;
+  selectors: string[];
+  position: IStylePosition;
+  file: string;
+  code: string;
+}
+
+// Find style property by className, in some CSS files.
+export function findStyle(directory: string, className: string, styleDependencies: IStyleDependency[] = []): IStyle | undefined {
+  let matched: IStyle | undefined;
+
+  for (let i = 0, l = styleDependencies.length; i < l; i++) {
+    const file = path.join(directory, styleDependencies[i].source);
+    const stylesheet = css.parse(fs.readFileSync(file, 'utf-8')).stylesheet;
+
+    matched = stylesheet.rules.find(rule => rule.selectors.includes(`.${className}`));
+
+    // Just find one matched stylesheet.
+    if (matched) {
+      matched.file = file;
+      matched.code = css.stringify({
+        type: 'stylesheet',
+        stylesheet: { rules: [matched] }
+      });
+      break;
+    }
+  }
+
+  return matched;
+};

--- a/extensions/iceworks-style-helper/src/styleInfoViewer/findStyleDependencies.ts
+++ b/extensions/iceworks-style-helper/src/styleInfoViewer/findStyleDependencies.ts
@@ -1,0 +1,40 @@
+import * as fs from 'fs';
+import * as babelParser from '@babel/parser';
+import traverse from '@babel/traverse';
+
+// import styles from './xxx.css'; -> { source: './xxx.css', identifier: 'styles' }
+// import './xxx.css'; -> { source: './xxx.css', identifier: null }
+export interface IStyleDependency {
+  source: string;
+  identifier: string | null;
+}
+
+// Find style dependencies, like import style form './index.css';
+export function findStyleDependencies(file: string) {
+  const StyleDependencies: IStyleDependency[] = [];
+
+  try {
+    const ast = babelParser.parse(fs.readFileSync(file, 'utf-8'), {
+      // Support JSX and TS
+      plugins: ['typescript', 'jsx'],
+      sourceType: 'module',
+    });
+
+    traverse(ast, {
+      ImportDeclaration(path) {
+        const { node } = path;
+        if (/\.css$/i.test(node.source.value)) {
+          StyleDependencies.push({
+            source: node.source.value,
+            // Just return first identifier.
+            identifier: node.specifiers[0] ? node.specifiers[0].local.name : null
+          });
+        }
+      }
+    });
+  } catch (e) {
+    // ignore
+  }
+
+  return StyleDependencies;
+};

--- a/extensions/iceworks-style-helper/src/styleInfoViewer/findStyleSelectors.ts
+++ b/extensions/iceworks-style-helper/src/styleInfoViewer/findStyleSelectors.ts
@@ -1,0 +1,23 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import css from 'css';
+import { IStyle } from './findStyle';
+import { IStyleDependency } from './findStyleDependencies';
+
+// Find styles selectors, ['.wrap', '.header' ....]
+export default function findStyleSelectors(directory: string, styleDependencies: IStyleDependency[] = []): string[] {
+  let selectors: string[] = [];
+
+  for (let i = 0, l = styleDependencies.length; i < l; i++) {
+    const file = path.join(directory, styleDependencies[i].source);
+    const stylesheet = css.parse(fs.readFileSync(file, 'utf-8')).stylesheet;
+
+    // eslint-disable-next-line
+    stylesheet.rules.forEach((rule: IStyle) => {
+      selectors = selectors.concat(rule.selectors);
+    });
+  }
+
+  return selectors;
+};
+

--- a/extensions/iceworks-style-helper/src/styleInfoViewer/index.ts
+++ b/extensions/iceworks-style-helper/src/styleInfoViewer/index.ts
@@ -1,0 +1,93 @@
+import * as vscode from 'vscode';
+import { findStyle, IStylePosition } from './findStyle';
+import { findStyleDependencies } from './findStyleDependencies';
+import findStyleSelectors from './findStyleSelectors';
+import { getFocusCodeInfo } from '../getFocusCodeInfo';
+
+const SUPPORT_LANGUAGES = [
+  'javascript',
+  'javascriptreact',
+  'typescript',
+  'typescriptreact'
+];
+
+// Cmd+Click jump to style definition
+function provideDefinition(document: vscode.TextDocument, position: vscode.Position) {
+  const { line, word, fileName, directory } = getFocusCodeInfo(document, position);
+
+  if (!/style|className/g.test(line.text)) return;
+
+  const matched = findStyle(directory, word, findStyleDependencies(fileName));
+  if (matched) {
+    const matchedPosition: IStylePosition = matched.position;
+    return new vscode.Location(
+      vscode.Uri.file(matched.file),
+      // The zero-based line and character value.
+      new vscode.Position(matchedPosition.start.line - 1, matchedPosition.start.column - 1)
+    );
+  }
+}
+
+// Show current style on hover over
+function provideHover(document: vscode.TextDocument, position: vscode.Position) {
+  const { line, word, fileName, directory } = getFocusCodeInfo(document, position);
+
+  if (!/style|className/g.test(line.text)) return;
+
+  const matched = findStyle(directory, word, findStyleDependencies(fileName));
+  if (matched) {
+    // Markdown css code
+    return new vscode.Hover(`\`\`\`css \n ${matched.code} \n \`\`\`\``);
+  }
+}
+
+// Styles auto Complete
+function provideCompletionItems(document: vscode.TextDocument, position: vscode.Position) {
+  const { line, fileName, directory } = getFocusCodeInfo(document, position);
+  if (!/style|className/g.test(line.text)) return;
+
+  // In case of cursor shaking
+  const word = line.text.substring(0, position.character);
+  const styleDependencies = findStyleDependencies(fileName);
+
+  for (let i = 0, l = styleDependencies.length; i < l; i++) {
+    if (styleDependencies[i].identifier && new RegExp(`${styleDependencies[i].identifier}\\.$`).test(word)) {
+      return findStyleSelectors(directory, styleDependencies).map((selector: string) => {
+        // Remove class selector `.`, When use styles.xxx.
+        return new vscode.CompletionItem(selector.replace('.', ''), vscode.CompletionItemKind.Variable);
+      });
+    }
+  }
+}
+
+export default function styleInfoViewer(context: vscode.ExtensionContext) {
+  // Cmd+Click jump to style definition
+  context.subscriptions.push(
+    vscode.languages.registerDefinitionProvider(
+      SUPPORT_LANGUAGES,
+      { provideDefinition }
+    )
+  );
+
+  SUPPORT_LANGUAGES.forEach((language) => {
+    // Show current style on hover over
+    context.subscriptions.push(
+      vscode.languages.registerHoverProvider(
+        language,
+        { provideHover }
+      )
+    );
+
+    // Styles auto Complete
+    context.subscriptions.push(
+      vscode.languages.registerCompletionItemProvider(
+        language,
+        { provideCompletionItems },
+        // match [styles identifier].xxx
+        // Example: `import test from './xxx.css'` match test.xxx;
+        '.'
+      )
+    );
+  });
+}
+


### PR DESCRIPTION
When editing the 'class' name of a CSS, LESS or SASS file, an automatic completion reminder will be given:

![demo](https://img.alicdn.com/tfs/TB1l_zMFhD1gK0jSZFKXXcJrVXa-500-355.gif)

Automatic completion When editing the 'style' name of a component in a JSX file, Use `cmd + click`  (Windows: `ctrl + click`) jump to the identifier under the cursor.

![demo](https://img.alicdn.com/tfs/TB1pb1ltYY1gK0jSZTEXXXDQVXa-1468-906.gif)

![demo](https://img.alicdn.com/tfs/TB1UDGht.Y1gK0jSZFMXXaWcVXa-1468-906.gif)