### PR TITLE
Feat: throw friendly error in download scaffold

### DIFF
--- a/packages/generate-project/package.json
+++ b/packages/generate-project/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iceworks/generate-project",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Generator project",
   "files": [
     "lib/"

--- a/packages/generate-project/src/index.ts
+++ b/packages/generate-project/src/index.ts
@@ -14,7 +14,16 @@ export async function downloadAndGenerateProject(
   projectDir: string, npmName: string, version?: string, registry?: string, projectName?: string
 ): Promise<void> {
   registry = registry || await getNpmRegistry(npmName);
-  const tarballURL = await getNpmTarball(npmName, version || 'latest', registry);
+  let tarballURL: string;
+  try {
+    tarballURL = await getNpmTarball(npmName, version || 'latest', registry);
+  } catch (error) {
+    if (error.statusCode === 404) {
+      return Promise.reject(new Error(`获取模板 npm 信息失败，当前的模板地址是：${registry}/${npmName}。`));
+    } else {
+      return Promise.reject(error);
+    }
+  }
 
   console.debug('download tarballURL', tarballURL);
 

--- a/packages/ice-npm-utils/package.json
+++ b/packages/ice-npm-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ice-npm-utils",
-  "version": "2.0.1",
+  "version": "2.0.0",
   "description": "npm utils for ice",
   "main": "lib/index.js",
   "files": [

--- a/packages/ice-npm-utils/package.json
+++ b/packages/ice-npm-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ice-npm-utils",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "npm utils for ice",
   "main": "lib/index.js",
   "files": [

--- a/packages/ice-npm-utils/src/index.ts
+++ b/packages/ice-npm-utils/src/index.ts
@@ -120,7 +120,7 @@ function getNpmInfo(npm: string, registry?: string): Promise<any> {
     }
 
     return body;
-  })
+  });
 }
 
 /**

--- a/packages/ice-npm-utils/src/index.ts
+++ b/packages/ice-npm-utils/src/index.ts
@@ -120,13 +120,7 @@ function getNpmInfo(npm: string, registry?: string): Promise<any> {
     }
 
     return body;
-  }, (error) => {
-    if (error.statusCode === 404) {
-      return Promise.reject(new Error(`获取模板 npm 信息失败，当前的模板地址是：${url}。请检查配置的镜像源地址是否正确。`));
-    } else {
-      return Promise.reject(error);
-    }
-  });
+  })
 }
 
 /**

--- a/packages/ice-npm-utils/src/index.ts
+++ b/packages/ice-npm-utils/src/index.ts
@@ -120,6 +120,12 @@ function getNpmInfo(npm: string, registry?: string): Promise<any> {
     }
 
     return body;
+  }, (error) => {
+    if (error.statusCode === 404) {
+      return Promise.reject(new Error(`获取模板 npm 信息失败，当前的模板地址是：${url}。请检查配置的镜像源地址是否正确。`));
+    } else {
+      return Promise.reject(error);
+    }
   });
 }
 


### PR DESCRIPTION
## 背景
现在 iceworks 创建项目使用的镜像源地址是默认读取 settings.json 中的镜像源地址。如果用户是使用自定义镜像源，可能没有配置自定义镜像源，导致下载模板失败，如下图：

图来自 #胜枫（社区群）
![image](https://user-images.githubusercontent.com/44047106/86312823-24de9e00-bc56-11ea-82db-994adce9e727.png)

## 解决
在 `getNpmInfo` 方法中，当获取不到模板信息时候（就是地址错了），给出友好的错误提示信息

![image](https://user-images.githubusercontent.com/44047106/86313024-ad5d3e80-bc56-11ea-8370-c30924c244ca.png)
