### PR TITLE
Fix: remove source map

### DIFF
--- a/extensions/iceworks-app/webpack.config.js
+++ b/extensions/iceworks-app/webpack.config.js
@@ -10,7 +10,6 @@ const config = {
     libraryTarget: 'commonjs2',
     devtoolModuleFilenameTemplate: '../[resource-path]'
   },
-  devtool: 'source-map',
   externals: {
     vscode: 'commonjs vscode'
   },

--- a/extensions/iceworks-component-builder/webpack.config.js
+++ b/extensions/iceworks-component-builder/webpack.config.js
@@ -11,7 +11,6 @@ const config = {
     libraryTarget: 'commonjs2',
     devtoolModuleFilenameTemplate: '../[resource-path]'
   },
-  devtool: 'source-map',
   externals: {
     vscode: 'commonjs vscode'
   },

--- a/extensions/iceworks-material-import/webpack.config.js
+++ b/extensions/iceworks-material-import/webpack.config.js
@@ -11,7 +11,6 @@ const config = {
     libraryTarget: 'commonjs2',
     devtoolModuleFilenameTemplate: '../[resource-path]'
   },
-  devtool: 'source-map',
   externals: {
     vscode: 'commonjs vscode'
   },

--- a/extensions/iceworks-page-builder/webpack.config.js
+++ b/extensions/iceworks-page-builder/webpack.config.js
@@ -11,7 +11,6 @@ const config = {
     libraryTarget: 'commonjs2',
     devtoolModuleFilenameTemplate: '../[resource-path]'
   },
-  devtool: 'source-map',
   externals: {
     vscode: 'commonjs vscode'
   },

--- a/extensions/iceworks-project-creator/webpack.config.js
+++ b/extensions/iceworks-project-creator/webpack.config.js
@@ -11,7 +11,6 @@ const config = {
     libraryTarget: 'commonjs2',
     devtoolModuleFilenameTemplate: '../[resource-path]'
   },
-  devtool: 'source-map',
   externals: {
     vscode: 'commonjs vscode'
   },


### PR DESCRIPTION

在生产环境中开启了 source-map，构建产物过大，terser 压缩文件造成内存溢出

解决：
生产环境中不开启 source-map