### PR TITLE
fix: project creator reopen fail

### DIFF
--- a/extensions/iceworks-project-creator/src/extension.ts
+++ b/extensions/iceworks-project-creator/src/extension.ts
@@ -17,7 +17,7 @@ export function activate(context: vscode.ExtensionContext) {
   // auto set configuration
   initExtension(context);
 
-  let webviewPanel: vscode.WebviewPanel;
+  let webviewPanel: vscode.WebviewPanel | undefined;
 
   function activeWebview() {
     logger.recordDAU();
@@ -31,6 +31,13 @@ export function activate(context: vscode.ExtensionContext) {
         retainContextWhenHidden: true,
       });
       webviewPanel.webview.html = getHtmlForWebview(extensionPath);
+      webviewPanel.onDidDispose(
+        () => {
+          webviewPanel = undefined;
+        },
+        null,
+        context.subscriptions
+      );
       connectService(webviewPanel, context, { services, logger });
     }
   }


### PR DESCRIPTION
问题：
插件第二次打开失败
![project-creator-problem](https://user-images.githubusercontent.com/44047106/87243966-fee2a600-c46c-11ea-9d8b-8539f4ce6809.gif)

解决：
当关闭插件时，需将当前的 webviewPanel 设为 undefined 
