### PR TITLE
fix: change material setting entry to Iceworks setting

### DIFF
--- a/extensions/iceworks-component-builder/CHANGELOG.md
+++ b/extensions/iceworks-component-builder/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.1.10
+
+Change the material setting entry to Iceworks setting. 
+
 ## 0.1.9
 
 Use webpack to build this extension.

--- a/extensions/iceworks-component-builder/package.json
+++ b/extensions/iceworks-component-builder/package.json
@@ -3,7 +3,7 @@
   "displayName": "Iceworks Component Builder",
   "description": "Build Component UI by low-code way",
   "publisher": "iceworks-team",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "engines": {
     "vscode": "^1.41.0"
   },

--- a/extensions/iceworks-component-builder/web/src/pages/Home/index.tsx
+++ b/extensions/iceworks-component-builder/web/src/pages/Home/index.tsx
@@ -6,7 +6,7 @@ import styles from './index.module.scss';
 
 async function onSettingsClick() {
   try {
-    await callService('common', 'executeCommand', 'workbench.action.openSettings', 'iceworks.materialSources');
+    await callService('common', 'executeCommand', 'iceworksApp.configHelper.start');
   } catch (e) {
     Notification.error({ content: e.message });
   }

--- a/extensions/iceworks-page-builder/CHANGELOG.md
+++ b/extensions/iceworks-page-builder/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.1.10
+
+Change the material setting entry to Iceworks setting. 
+
 ## 0.1.9
 
 Use webpack to build this extension.

--- a/extensions/iceworks-page-builder/package.json
+++ b/extensions/iceworks-page-builder/package.json
@@ -3,7 +3,7 @@
   "displayName": "Iceworks Page Builder",
   "description": "Build Page UI by low-code way",
   "publisher": "iceworks-team",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "repository": {
     "type": "git",
     "url": "https://github.com/ice-lab/iceworks.git"

--- a/extensions/iceworks-page-builder/web/src/pages/Home/index.tsx
+++ b/extensions/iceworks-page-builder/web/src/pages/Home/index.tsx
@@ -46,7 +46,7 @@ const Home = () => {
 
   async function onSettingsClick() {
     try {
-      await callService('common', 'executeCommand', 'workbench.action.openSettings', 'iceworks.materialSources');
+      await callService('common', 'executeCommand', 'iceworksApp.configHelper.start');
     } catch (e) {
       Notification.error({ content: e.message });
     }


### PR DESCRIPTION
iceworks-page-builder 和 iceworks-component-builder 的物料源设置入口统一改到 Iceworks 设置面板中

效果：

![test](https://user-images.githubusercontent.com/44047106/87509569-6898c500-c6a4-11ea-8bb1-7217255944d4.gif)
