### PR TITLE
fix: web i18n

### DIFF
--- a/extensions/iceworks-component-builder/src/i18n.ts
+++ b/extensions/iceworks-component-builder/src/i18n.ts
@@ -3,7 +3,6 @@ import I18nService from '@iceworks/i18n';
 import * as zhCNTextMap from './locales/zh-CN.json';
 import * as enUSTextMap from './locales/en-US.json';
 
-
 // 注册语言表
 const i18n = new I18nService();
 

--- a/extensions/iceworks-component-builder/web/src/i18n.tsx
+++ b/extensions/iceworks-component-builder/web/src/i18n.tsx
@@ -1,11 +1,9 @@
 import { createIntl, RawIntlProvider } from 'react-intl'; 
 import React, { useEffect, useState } from 'react'
 import { ConfigProvider, Loading } from '@alifd/next';
-
-// 引入 locale 配置文件
+import callService from './callService';
 import enUSLocale from './locales/en-US.json';
 import zhCNLocale from './locales/zh-CN.json';
-import callService from './callService';
 
 const DEFAULT_LANG = 'zh-cn';
 

--- a/extensions/iceworks-component-builder/web/src/i18n.tsx
+++ b/extensions/iceworks-component-builder/web/src/i18n.tsx
@@ -1,6 +1,6 @@
 import { createIntl, RawIntlProvider } from 'react-intl'; 
 import React, { useEffect, useState } from 'react'
-import { ConfigProvider, Loading, Notification } from '@alifd/next';
+import { ConfigProvider, Loading } from '@alifd/next';
 
 // 引入 locale 配置文件
 import enUSLocale from './locales/en-US.json';

--- a/extensions/iceworks-component-builder/web/src/i18n.tsx
+++ b/extensions/iceworks-component-builder/web/src/i18n.tsx
@@ -38,7 +38,7 @@ export const LocaleProvider = (props)=>{
         const lang = await callService('common', 'getLanguage');
         setI18n(getIntl(lang));
       } catch(e) {
-        Notification.error({ content: e.message });
+        // ignore i18n error, just using default language
       } finally {
         setLoading(false);
       }

--- a/extensions/iceworks-component-builder/web/src/i18n.tsx
+++ b/extensions/iceworks-component-builder/web/src/i18n.tsx
@@ -48,7 +48,7 @@ export const LocaleProvider = (props)=>{
 
   return (
     <RawIntlProvider value={i18n}>
-        <ConfigProvider locale={localeMessages[i18n.locale].nextMessages}>
+      <ConfigProvider locale={localeMessages[i18n.locale].nextMessages}>
         {loading ? <Loading visible={loading} style={{width: '100%', height:'80vh'}} /> : React.Children.only(props.children)}
       </ConfigProvider>
     </RawIntlProvider>

--- a/extensions/iceworks-component-builder/web/src/i18n.tsx
+++ b/extensions/iceworks-component-builder/web/src/i18n.tsx
@@ -1,34 +1,36 @@
 import { createIntl, RawIntlProvider } from 'react-intl'; 
 import React, { useEffect, useState } from 'react'
 import { ConfigProvider, Loading } from '@alifd/next';
-import callService from './callService';
-import enUSLocale from './locales/en-US.json';
-import zhCNLocale from './locales/zh-CN.json';
+import enUSNextMessages from '@alifd/next/lib/locale/en-us';
+import zhCNNextMessages from '@alifd/next/lib/locale/zh-cn';
 
-const DEFAULT_LANG = 'zh-cn';
+import callService from './callService';
+import enUSMessages from './locales/en-US.json';
+import zhCNMessages from './locales/zh-CN.json';
+
+const DEFAULT_LOCALE = 'zh-cn';
 
 export const localeMessages = {
   'en': {
-    messages:enUSLocale,
-    nextLocale:'zhCN',
-    reactLocale:'zh-CN'
+    messages: enUSMessages,
+    nextMessages: enUSNextMessages,
   },
   'zh-cn':{
-    messages:zhCNLocale,
-    nextLocal:'enUS',
-    reactLocale:'en'
-  }
-}
+    messages: zhCNMessages,
+    nextMessages: zhCNNextMessages,
+  },
+};
 
-const getIntl = (lang: string) =>{
-  let localeMessage = localeMessages[lang];
+const getIntl = (locale: string) =>{
+  let localeMessage = localeMessages[locale];
   if (!localeMessage) {
-    localeMessage = localeMessages[DEFAULT_LANG];
+    locale = DEFAULT_LOCALE;
+    localeMessage = localeMessages[locale];
   }
-  return createIntl({locale: localeMessage.reactLocale, messages: localeMessage.messages});
+  return createIntl({locale, messages: localeMessage.messages});
 }
 export const LocaleProvider = (props)=>{
-  const [i18n, setI18n] = useState(() => getIntl(DEFAULT_LANG));
+  const [i18n, setI18n] = useState(() => getIntl(DEFAULT_LOCALE));
   const [loading, setLoading] = useState(true)
   useEffect(()=>{
     async function initI18n(){
@@ -46,7 +48,7 @@ export const LocaleProvider = (props)=>{
 
   return (
     <RawIntlProvider value={i18n}>
-      <ConfigProvider>
+        <ConfigProvider locale={localeMessages[i18n.locale].nextMessages}>
         {loading ? <Loading visible={loading} style={{width: '100%', height:'80vh'}} /> : React.Children.only(props.children)}
       </ConfigProvider>
     </RawIntlProvider>

--- a/extensions/iceworks-component-builder/web/src/i18n.tsx
+++ b/extensions/iceworks-component-builder/web/src/i18n.tsx
@@ -44,7 +44,6 @@ export const LocaleProvider = (props)=>{
       }
     }
     initI18n();
-    
   },[]);
 
   return (

--- a/extensions/iceworks-component-builder/web/src/pages/Home/index.tsx
+++ b/extensions/iceworks-component-builder/web/src/pages/Home/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Notification, Button, Input } from '@alifd/next';
 import Material from '@iceworks/material-ui';
-import { LocaleProvider, checkI18nReady } from '@/i18n';
+import { LocaleProvider } from '@/i18n';
 import { useIntl, FormattedMessage } from 'react-intl';
 import callService from '../../callService';
 import styles from './index.module.scss';
@@ -22,9 +22,6 @@ const Home = () => {
   }
   
   async function getSources() {
-    if(!checkI18nReady(intl)){
-      return;
-    }
     let sources = [];
     try {
       sources = await callService('material', 'getSourcesByProjectType');
@@ -37,9 +34,6 @@ const Home = () => {
   }
   
   async function getData(source: string) {
-    if(!checkI18nReady(intl)){
-      return;
-    }
     let data = {};
     try {
       data = await callService('material', 'getData', source);


### PR DESCRIPTION
0. 功能完备性：支持 `@alifd/next` 的国际化：https://github.com/alibaba-fusion/next/blob/master/site/en-us/i18n.md
0. 程序正确性：loading 的初始化值为 `true`，确保获取语言包后再开始渲染
0. 程序容错性：需要有默认语言，确保语言不支持时使用默认的语言
0. 代码一致性：createIntl 方法的封装使用