### PR TITLE
Fix: fail to debug extension in development env

### DIFF
--- a/extensions/iceworks-app/package.json
+++ b/extensions/iceworks-app/package.json
@@ -383,7 +383,7 @@
     "vscode:prepublish": "rm -rf build && npm run build:web && webpack --mode production",
     "build:web": "cd web && npm run build",
     "watch:web": "cd web && npm run start",
-    "webpack": "rm -rf ./build/extension.js && webpack --mode development",
+    "webpack": "webpack --mode development",
     "webpack-dev": "webpack --mode development --watch",
     "compile": "tsc -p ./tsconfig.json"
   },

--- a/extensions/iceworks-app/webpack.config.js
+++ b/extensions/iceworks-app/webpack.config.js
@@ -34,4 +34,10 @@ const config = {
   }
 };
 
-module.exports = config;
+module.exports = (env, argv) => {
+  if (argv.mode === 'development') {
+    config.devtool = 'source-map';
+  }
+
+  return config;
+};

--- a/extensions/iceworks-component-builder/webpack.config.js
+++ b/extensions/iceworks-component-builder/webpack.config.js
@@ -36,4 +36,10 @@ const config = {
   }
 };
 
-module.exports = config;
+module.exports = (env, argv) => {
+  if (argv.mode === 'development') {
+    config.devtool = 'source-map';
+  }
+
+  return config;
+};

--- a/extensions/iceworks-material-helper/webpack.config.js
+++ b/extensions/iceworks-material-helper/webpack.config.js
@@ -36,4 +36,10 @@ const config = {
   }
 };
 
-module.exports = config;
+module.exports = (env, argv) => {
+  if (argv.mode === 'development') {
+    config.devtool = 'source-map';
+  }
+
+  return config;
+};

--- a/extensions/iceworks-page-builder/webpack.config.js
+++ b/extensions/iceworks-page-builder/webpack.config.js
@@ -36,4 +36,10 @@ const config = {
   }
 };
 
-module.exports = config;
+module.exports = (env, argv) => {
+  if (argv.mode === 'development') {
+    config.devtool = 'source-map';
+  }
+
+  return config;
+};

--- a/extensions/iceworks-project-creator/webpack.config.js
+++ b/extensions/iceworks-project-creator/webpack.config.js
@@ -35,4 +35,10 @@ const config = {
   }
 };
 
-module.exports = config;
+module.exports = (env, argv) => {
+  if (argv.mode === 'development') {
+    config.devtool = 'source-map';
+  }
+
+  return config;
+};


### PR DESCRIPTION
问题：在 dev 环境下，使用 webpack 进行打包的插件无法进行断点调试

解决： 在 development 环境下，引入 devtool = 'source-map'，在 production 环境下不引入