### PR TITLE
Fix: fail get material detail in unknown project

### DIFF
--- a/packages/material-service/package.json
+++ b/packages/material-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iceworks/material-service",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Iceworks material service for VSCode extension.",
   "files": [
     "lib"

--- a/packages/material-service/src/index.ts
+++ b/packages/material-service/src/index.ts
@@ -41,8 +41,12 @@ const isIceMaterial = (source: string) => {
 };
 
 export const getSourcesByProjectType = async function () {
-  const type = await getProjectType();
+  let type = await getProjectType();
   console.log('project type is:', type);
+  if (type === 'unknown') {
+    console.log('The current project type is unknown, so set the default project type: react');
+    type = 'react';
+  }
   return getSources(type);
 }
 

--- a/packages/material-service/src/index.ts
+++ b/packages/material-service/src/index.ts
@@ -41,12 +41,8 @@ const isIceMaterial = (source: string) => {
 };
 
 export const getSourcesByProjectType = async function () {
-  let type = await getProjectType();
+  const type = await getProjectType();
   console.log('project type is:', type);
-  if (type === 'unknown') {
-    console.log('The current project type is unknown, so set the default project type: react');
-    type = 'react';
-  }
   return getSources(type);
 }
 
@@ -58,6 +54,10 @@ export const getUserSources = () => getDataFromSettingJson(CONFIGURATION_KEY_MAT
  * @param specifiedType {string} react/rax/other...
  */
 export async function getSources(specifiedType?: string): Promise<IMaterialSource[]> {
+  if (specifiedType === 'unknown') {
+    // if the project type is unknown, set the default project type 
+    specifiedType = 'react'
+  }
   let officalsources: IMaterialSource[] = getOfficalMaterialSources();
   if (!await checkAliInternal()) {
     officalsources = officalsources.concat(OFFICAL_MATERIAL_SOURCES_FOR_EXTERNAL);


### PR DESCRIPTION
Closed: #319

当获取应用类型为 unknown 时，默认使用 react 物料源