### PR TITLE
Style: create editor menu action

### DIFF
--- a/extensions/iceworks-app/package.json
+++ b/extensions/iceworks-app/package.json
@@ -256,12 +256,7 @@
         {
           "command": "iceworksApp.npmScripts.runDev",
           "group": "navigation@01",
-          "when": "iceworks:showScriptIconInEditorTitleMenu && !iceworks:isRunningDev"
-        },
-        {
-          "command": "iceworksApp.npmScripts.stopDev",
-          "group": "navigation@01",
-          "when": "iceworks:showScriptIconInEditorTitleMenu && iceworks:isRunningDev"
+          "when": "iceworks:showScriptIconInEditorTitleMenu"
         },
         {
           "command": "iceworksApp.DefPublish",

--- a/extensions/iceworks-app/src/createEditorMenuAction.ts
+++ b/extensions/iceworks-app/src/createEditorMenuAction.ts
@@ -7,9 +7,6 @@ import showDefPublishEnvQuickPick from './quickPicks/showDefPublishEnvQuickPick'
 import executeCommand from './commands/executeCommand';
 import stopCommand from './commands/stopCommand';
 
-// eslint-disable-next-line
-const { version } = require('../package.json');
-
 export default function createEditorMenuAction(
   rootPath: string,
   terminals: ITerminalMap,

--- a/extensions/iceworks-app/src/createEditorMenuAction.ts
+++ b/extensions/iceworks-app/src/createEditorMenuAction.ts
@@ -5,13 +5,8 @@ import { editorTitleRunDevCommandId, editorTitleRunBuildCommandId } from './cons
 import { ITerminalMap } from './types';
 import showDefPublishEnvQuickPick from './quickPicks/showDefPublishEnvQuickPick';
 import executeCommand from './commands/executeCommand';
-import stopCommand from './commands/stopCommand';
 
-export default function createEditorMenuAction(
-  rootPath: string,
-  terminals: ITerminalMap,
-  isAliInternal: boolean,
-) {
+export default function createEditorMenuAction(rootPath: string, terminals: ITerminalMap, isAliInternal: boolean) {
   vscode.commands.registerCommand('iceworksApp.npmScripts.runDev', async () => {
     const pathExists = await checkPathExists(rootPath, dependencyDir);
     const command: vscode.Command = {
@@ -26,18 +21,12 @@ export default function createEditorMenuAction(
       return;
     }
     executeCommand(terminals, command, commandId);
-    vscode.commands.executeCommand('setContext', 'iceworks:isRunningDev', true);
-  });
-
-  vscode.commands.registerCommand('iceworksApp.npmScripts.stopDev', () => {
-    stopCommand(terminals, editorTitleRunDevCommandId);
-    vscode.commands.executeCommand('setContext', 'iceworks:isRunningDev', false);
   });
 
   if (isAliInternal) {
     vscode.commands.registerCommand('iceworksApp.DefPublish', () => {
       showDefPublishEnvQuickPick(terminals, rootPath);
-    })
+    });
   } else {
     vscode.commands.registerCommand('iceworksApp.npmScripts.runBuild', async () => {
       const pathExists = await checkPathExists(rootPath, dependencyDir);

--- a/extensions/iceworks-app/src/createEditorMenuAction.ts
+++ b/extensions/iceworks-app/src/createEditorMenuAction.ts
@@ -1,0 +1,61 @@
+import * as vscode from 'vscode';
+import { createNpmCommand, checkPathExists } from '@iceworks/common-service';
+import { dependencyDir } from '@iceworks/project-service';
+import { editorTitleRunDevCommandId, editorTitleRunBuildCommandId } from './constants';
+import { ITerminalMap } from './types';
+import showDefPublishEnvQuickPick from './quickPicks/showDefPublishEnvQuickPick';
+import executeCommand from './commands/executeCommand';
+import stopCommand from './commands/stopCommand';
+
+// eslint-disable-next-line
+const { version } = require('../package.json');
+
+export default function createEditorMenuAction(
+  rootPath: string,
+  terminals: ITerminalMap,
+  isAliInternal: boolean,
+) {
+  vscode.commands.registerCommand('iceworksApp.npmScripts.runDev', async () => {
+    const pathExists = await checkPathExists(rootPath, dependencyDir);
+    const command: vscode.Command = {
+      command: 'iceworksApp.npmScripts.runDev',
+      title: 'Run Dev',
+      arguments: [rootPath, createNpmCommand('run', 'start')],
+    };
+    const commandId = editorTitleRunDevCommandId;
+    if (!pathExists) {
+      command.arguments = [rootPath, `${createNpmCommand('install')} && ${command.arguments![1]}`];
+      executeCommand(terminals, command, commandId);
+      return;
+    }
+    executeCommand(terminals, command, commandId);
+    vscode.commands.executeCommand('setContext', 'iceworks:isRunningDev', true);
+  });
+
+  vscode.commands.registerCommand('iceworksApp.npmScripts.stopDev', () => {
+    stopCommand(terminals, editorTitleRunDevCommandId);
+    vscode.commands.executeCommand('setContext', 'iceworks:isRunningDev', false);
+  });
+
+  if (isAliInternal) {
+    vscode.commands.registerCommand('iceworksApp.DefPublish', () => {
+      showDefPublishEnvQuickPick(terminals, rootPath);
+    })
+  } else {
+    vscode.commands.registerCommand('iceworksApp.npmScripts.runBuild', async () => {
+      const pathExists = await checkPathExists(rootPath, dependencyDir);
+      const command: vscode.Command = {
+        command: 'iceworksApp.npmScripts.runBuild',
+        title: 'Run Build',
+        arguments: [rootPath, createNpmCommand('run', 'build')],
+      };
+      const commandId = editorTitleRunBuildCommandId;
+      if (!pathExists) {
+        command.arguments = [rootPath, `${createNpmCommand('install')} && ${command.arguments![1]}`];
+        executeCommand(terminals, command, commandId);
+        return;
+      }
+      executeCommand(terminals, command, commandId);
+    });
+  }
+}

--- a/extensions/iceworks-app/src/extension.ts
+++ b/extensions/iceworks-app/src/extension.ts
@@ -56,7 +56,7 @@ export async function activate(context: vscode.ExtensionContext) {
   );
 
   if (!rootPath) {
-    vscode.window.showInformationMessage(i18n.format('extension.iceworksApp.extebsion.emptyWorkplace'));
+    window.showInformationMessage(i18n.format('extension.iceworksApp.extebsion.emptyWorkplace'));
     vscode.commands.executeCommand('setContext', 'iceworks:isNotTargetProject', true);
     vscode.commands.executeCommand('iceworks-project-creator.start');
     return;
@@ -75,6 +75,10 @@ export async function activate(context: vscode.ExtensionContext) {
   }
 
   const terminals: ITerminalMap = new Map<string, Terminal>();
+  // remove terminal from terminals map
+  window.onDidCloseTerminal((terminal) => {
+    terminals.delete(terminal.name);
+  });
 
   // init tree data providers
   createNpmScriptsTreeProvider(context, rootPath, terminals);

--- a/extensions/iceworks-app/src/extension.ts
+++ b/extensions/iceworks-app/src/extension.ts
@@ -11,7 +11,7 @@ import { ITerminalMap } from './types';
 import services from './services';
 import { showExtensionsQuickPickCommandId } from './constants';
 import showExtensionsQuickPick from './quickPicks/showExtensionsQuickPick';
-import showDefPublishEnvQuickPick from './quickPicks/showDefPublishEnvQuickPick';
+import createEditorMenuAction from './createEditorMenuAction';
 import createExtensionsStatusBar from './statusBar/createExtensionsStatusBar';
 import i18n from './i18n';
 
@@ -61,6 +61,7 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.commands.executeCommand('iceworks-project-creator.start');
     return;
   }
+
   try {
     const projectType = await getProjectType();
     const isNotTargetProject = projectType === 'unknown';
@@ -74,19 +75,16 @@ export async function activate(context: vscode.ExtensionContext) {
   }
 
   const terminals: ITerminalMap = new Map<string, Terminal>();
+
   // init tree data providers
   createNpmScriptsTreeProvider(context, rootPath, terminals);
   createComponentsTreeProvider(context, rootPath);
   createPagesTreeProvider(context, rootPath);
   createNodeDependenciesTreeProvider(context, rootPath, terminals);
+
   // show script icons in editor title menu
   vscode.commands.executeCommand('setContext', 'iceworks:showScriptIconInEditorTitleMenu', true);
   const isAliInternal = await checkIsAliInternal();
-  // DEF publish command in editor title
   vscode.commands.executeCommand('setContext', 'iceworks:isAliInternal', isAliInternal);
-  if (isAliInternal) {
-    context.subscriptions.push(
-      vscode.commands.registerCommand('iceworksApp.DefPublish', () => showDefPublishEnvQuickPick(terminals, rootPath))
-    );
-  }
+  createEditorMenuAction(rootPath, terminals, isAliInternal);
 }

--- a/extensions/iceworks-app/src/views/nodeDependenciesView.ts
+++ b/extensions/iceworks-app/src/views/nodeDependenciesView.ts
@@ -208,20 +208,16 @@ export function createNodeDependenciesTreeProvider(context, rootPath, terminals)
     }
   });
 
-  context.subscriptions.push(
-    vscode.commands.registerCommand('iceworksApp.nodeDependencies.dependencies.add', () =>
-      showDepsInputBox(terminals, nodeDependenciesProvider, 'dependencies')
-    )
+  vscode.commands.registerCommand('iceworksApp.nodeDependencies.dependencies.add', () =>
+    showDepsInputBox(terminals, nodeDependenciesProvider, 'dependencies')
   );
-  context.subscriptions.push(
-    vscode.commands.registerCommand('iceworksApp.nodeDependencies.devDependencies.add', () =>
-      showDepsInputBox(terminals, nodeDependenciesProvider, 'devDependencies')
-    )
+
+  vscode.commands.registerCommand('iceworksApp.nodeDependencies.devDependencies.add', () =>
+    showDepsInputBox(terminals, nodeDependenciesProvider, 'devDependencies')
   );
-  context.subscriptions.push(
-    vscode.commands.registerCommand('iceworksApp.nodeDependencies.addDepsAndDevDeps', () =>
-      showDepsQuickPick(terminals, nodeDependenciesProvider)
-    )
+
+  vscode.commands.registerCommand('iceworksApp.nodeDependencies.addDepsAndDevDeps', () =>
+    showDepsQuickPick(terminals, nodeDependenciesProvider)
   );
 
   const pattern = path.join(rootPath, dependencyDir);
@@ -243,10 +239,10 @@ function toDep(
   const npmCommand = createNpmCommand(isYarn ? 'upgrade' : 'update', moduleName);
   const command = outdated
     ? {
-        command: 'iceworksApp.nodeDependencies.upgrade',
-        title: 'Upgrade Dependency',
-        arguments: [workspaceDir, npmCommand],
-      }
+      command: 'iceworksApp.nodeDependencies.upgrade',
+      title: 'Upgrade Dependency',
+      arguments: [workspaceDir, npmCommand],
+    }
     : undefined;
   return new DependencyTreeItem(
     extensionContext,

--- a/extensions/iceworks-app/src/views/nodeDependenciesView.ts
+++ b/extensions/iceworks-app/src/views/nodeDependenciesView.ts
@@ -239,10 +239,10 @@ function toDep(
   const npmCommand = createNpmCommand(isYarn ? 'upgrade' : 'update', moduleName);
   const command = outdated
     ? {
-      command: 'iceworksApp.nodeDependencies.upgrade',
-      title: 'Upgrade Dependency',
-      arguments: [workspaceDir, npmCommand],
-    }
+        command: 'iceworksApp.nodeDependencies.upgrade',
+        title: 'Upgrade Dependency',
+        arguments: [workspaceDir, npmCommand],
+      }
     : undefined;
   return new DependencyTreeItem(
     extensionContext,

--- a/extensions/iceworks-app/src/views/npmScriptsView.ts
+++ b/extensions/iceworks-app/src/views/npmScriptsView.ts
@@ -6,7 +6,6 @@ import { dependencyDir, packageJSONFilename } from '@iceworks/project-service';
 import executeCommand from '../commands/executeCommand';
 import stopCommand from '../commands/stopCommand';
 import { ITerminalMap } from '../types';
-import { editorTitleRunDevCommandId, editorTitleRunBuildCommandId } from '../constants';
 
 export class NpmScriptsProvider implements vscode.TreeDataProvider<ScriptTreeItem> {
   private workspaceRoot: string;

--- a/extensions/iceworks-app/src/views/npmScriptsView.ts
+++ b/extensions/iceworks-app/src/views/npmScriptsView.ts
@@ -59,8 +59,8 @@ export class NpmScriptsProvider implements vscode.TreeDataProvider<ScriptTreeIte
 
       const scripts = packageJson.scripts
         ? Object.keys(packageJson.scripts).map((script) =>
-            toScript(script, packageJson.scripts[script], `npmScripts-${script}`)
-          )
+          toScript(script, packageJson.scripts[script], `npmScripts-${script}`)
+        )
         : [];
       return scripts;
     } else {
@@ -110,45 +110,6 @@ export function createNpmScriptsTreeProvider(
     stopCommand(terminals, script.id)
   );
   vscode.commands.registerCommand('iceworksApp.npmScripts.refresh', () => npmScriptsProvider.refresh());
-
-  // commands in editor title
-  vscode.commands.registerCommand('iceworksApp.npmScripts.runDev', async () => {
-    const pathExists = await checkPathExists(rootPath, dependencyDir);
-    const command: vscode.Command = {
-      command: 'iceworksApp.npmScripts.runDev',
-      title: 'Run Dev',
-      arguments: [rootPath, createNpmCommand('run', 'start')],
-    };
-    const commandId = editorTitleRunDevCommandId;
-    if (!pathExists) {
-      command.arguments = [rootPath, `${createNpmCommand('install')} && ${command.arguments![1]}`];
-      executeCommand(terminals, command, commandId);
-      return;
-    }
-    executeCommand(terminals, command, commandId);
-    vscode.commands.executeCommand('setContext', 'iceworks:isRunningDev', true);
-  });
-
-  vscode.commands.registerCommand('iceworksApp.npmScripts.stopDev', () => {
-    stopCommand(terminals, editorTitleRunDevCommandId);
-    vscode.commands.executeCommand('setContext', 'iceworks:isRunningDev', false);
-  });
-
-  vscode.commands.registerCommand('iceworksApp.npmScripts.runBuild', async () => {
-    const pathExists = await checkPathExists(rootPath, dependencyDir);
-    const command: vscode.Command = {
-      command: 'iceworksApp.npmScripts.runBuild',
-      title: 'Run Build',
-      arguments: [rootPath, createNpmCommand('run', 'build')],
-    };
-    const commandId = editorTitleRunBuildCommandId;
-    if (!pathExists) {
-      command.arguments = [rootPath, `${createNpmCommand('install')} && ${command.arguments![1]}`];
-      executeCommand(terminals, command, commandId);
-      return;
-    }
-    executeCommand(terminals, command, commandId);
-  });
 
   const pattern = path.join(rootPath, packageJSONFilename);
   const fileWatcher = vscode.workspace.createFileSystemWatcher(pattern);

--- a/extensions/iceworks-app/src/views/npmScriptsView.ts
+++ b/extensions/iceworks-app/src/views/npmScriptsView.ts
@@ -58,8 +58,8 @@ export class NpmScriptsProvider implements vscode.TreeDataProvider<ScriptTreeIte
 
       const scripts = packageJson.scripts
         ? Object.keys(packageJson.scripts).map((script) =>
-          toScript(script, packageJson.scripts[script], `npmScripts-${script}`)
-        )
+            toScript(script, packageJson.scripts[script], `npmScripts-${script}`)
+          )
         : [];
       return scripts;
     } else {


### PR DESCRIPTION
- 抽离 createEditorMenuAction 方法，用于注册在编辑器右上角的按钮命令（启动调试、构建项目、DEF 发布、设置入口）
- 暂时移除编辑器右上角的停止按钮（由于当前调用VSCode中的集成终端运行脚本，无法实时获取输出流  [Ref: VSCode issues](https://github.com/microsoft/vscode/issues/59384)
），这个点需要 hold 一下