### PR TITLE
Fix: no material display in empty workspace

### DIFF
--- a/packages/project-service/package.json
+++ b/packages/project-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iceworks/project-service",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "Iceworks project service for VSCode extension.",
   "files": [
     "lib"

--- a/packages/project-service/src/index.ts
+++ b/packages/project-service/src/index.ts
@@ -52,7 +52,8 @@ export async function getProjectType() {
       return 'vue';
     }
     return 'unknown';
-  } catch  {
+  } catch (e) {
+    console.error(e);
     return 'unknown';
   }
 }

--- a/packages/project-service/src/index.ts
+++ b/packages/project-service/src/index.ts
@@ -40,17 +40,21 @@ export async function getProjectLanguageType() {
 }
 
 export async function getProjectType() {
-  const { dependencies = {} } = await readPackageJSON(projectPath);
-  if (dependencies.rax) {
-    return 'rax';
+  try {
+    const { dependencies = {} } = await readPackageJSON(projectPath);
+    if (dependencies.rax) {
+      return 'rax';
+    }
+    if (dependencies.react) {
+      return 'react';
+    }
+    if (dependencies.vue) {
+      return 'vue';
+    }
+    return 'unknown';
+  } catch  {
+    return 'unknown';
   }
-  if (dependencies.react) {
-    return 'react';
-  }
-  if (dependencies.vue) {
-    return 'vue';
-  }
-  return 'unknown';
 }
 
 export async function getProjectFramework() {


### PR DESCRIPTION
Fix:  修复在空工作区（在空工作区根路径下，没有找到 `package.json` 文件）中打开物料面板不显示默认物料的问题
