### PR TITLE
Fix: stop command fail

### DIFF
--- a/extensions/iceworks-app/CHANGELOG.md
+++ b/extensions/iceworks-app/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Change Log
 
 ## 0.4.6
-- Support pegasus project debugger.
+- feat: support pegasus project debugger.
 - feat: add quick entries in tree view.
+- fix: stop command fail.
 
 ## 0.4.5
 - feat: add component-generator and component-creator quickPick.

--- a/extensions/iceworks-app/src/commands/executeCommand.ts
+++ b/extensions/iceworks-app/src/commands/executeCommand.ts
@@ -1,28 +1,24 @@
 import * as vscode from 'vscode';
 import { Terminal, TerminalOptions } from 'vscode';
-import { ITerminalMap } from '../types';
 
-export default function executeCommand(terminalMapping: ITerminalMap, script: vscode.Command, id?: string) {
-  if (!script.arguments) {
+export default function executeCommand(command: vscode.Command) {
+  if (!command.arguments) {
     return;
   }
-  const args = script.arguments;
-  const [cwd, command] = args;
-  if (!command) {
+  const args = command.arguments;
+  const [cwd, script] = args;
+  if (!script) {
     return;
   }
 
-  const terminalId = id || command;
-  let terminal: Terminal;
+  const terminals = vscode.window.terminals;
 
-  if (terminalMapping.has(terminalId)) {
-    terminal = terminalMapping.get(terminalId)!;
-  } else {
-    const terminalOptions: TerminalOptions = { cwd, name: command };
+  let terminal: Terminal | undefined = terminals.find((terminal: Terminal) => terminal.name === script);
+  if (!terminal) {
+    const terminalOptions: TerminalOptions = { cwd, name: script };
     terminal = vscode.window.createTerminal(terminalOptions);
-    terminalMapping.set(terminalId, terminal);
   }
 
   terminal.show();
-  terminal.sendText(command);
+  terminal.sendText(script);
 }

--- a/extensions/iceworks-app/src/commands/stopCommand.ts
+++ b/extensions/iceworks-app/src/commands/stopCommand.ts
@@ -8,9 +8,9 @@ export default function stopCommand(command: vscode.Command) {
   }
   const [cwd, script] = commandArgs;
   if (!script) {
-    return
+    return;
   }
-  const currentTerminal = terminals.find((terminal: vscode.Terminal) => terminal.name === script)
+  const currentTerminal = terminals.find((terminal: vscode.Terminal) => terminal.name === script);
   if (currentTerminal) {
     currentTerminal.dispose();
   }

--- a/extensions/iceworks-app/src/commands/stopCommand.ts
+++ b/extensions/iceworks-app/src/commands/stopCommand.ts
@@ -1,9 +1,17 @@
-import { ITerminalMap } from '../types';
+import * as vscode from 'vscode';
 
-export default function stopCommand(terminalMapping: ITerminalMap, scriptId: string) {
-  const currentTerminal = terminalMapping.get(scriptId);
+export default function stopCommand(command: vscode.Command) {
+  const terminals = vscode.window.terminals;
+  const commandArgs = command.arguments;
+  if (!commandArgs) {
+    return;
+  }
+  const [cwd, script] = commandArgs;
+  if (!script) {
+    return
+  }
+  const currentTerminal = terminals.find((terminal: vscode.Terminal) => terminal.name === script)
   if (currentTerminal) {
     currentTerminal.dispose();
-    terminalMapping.delete(scriptId);
   }
 }

--- a/extensions/iceworks-app/src/createEditorMenuAction.ts
+++ b/extensions/iceworks-app/src/createEditorMenuAction.ts
@@ -11,13 +11,11 @@ export default async function createEditorMenuAction() {
     // Check dependences
     if (!(await checkPathExists(projectPath, dependencyDir))) {
       vscode.window.showInformationMessage('"node_modules" directory not found! Install dependencies first.');
-      executeCommand(
-        {
-          command: EDITOR_MENU_RUN_DEBUG,
-          title: 'Run Install',
-          arguments: [projectPath, createNpmCommand('install')],
-        }
-      );
+      executeCommand({
+        command: EDITOR_MENU_RUN_DEBUG,
+        title: 'Run Install',
+        arguments: [projectPath, createNpmCommand('install')],
+      });
       return;
     }
 

--- a/extensions/iceworks-app/src/createEditorMenuAction.ts
+++ b/extensions/iceworks-app/src/createEditorMenuAction.ts
@@ -2,25 +2,21 @@ import * as vscode from 'vscode';
 import { createNpmCommand, checkPathExists, checkIsAliInternal, registerCommand } from '@iceworks/common-service';
 import { dependencyDir, projectPath } from '@iceworks/project-service';
 import { setDebugConfig } from './debugConfig/index';
-import { editorTitleRunDebugCommandId, editorTitleRunBuildCommandId } from './constants';
-import { ITerminalMap } from './types';
 import showDefPublishEnvQuickPick from './quickPicks/showDefPublishEnvQuickPick';
 import executeCommand from './commands/executeCommand';
 
-export default async function createEditorMenuAction(terminals: ITerminalMap) {
+export default async function createEditorMenuAction() {
   const EDITOR_MENU_RUN_DEBUG = 'iceworksApp.editorMenu.runDebug';
   registerCommand(EDITOR_MENU_RUN_DEBUG, async () => {
     // Check dependences
     if (!(await checkPathExists(projectPath, dependencyDir))) {
       vscode.window.showInformationMessage('"node_modules" directory not found! Install dependencies first.');
       executeCommand(
-        terminals,
         {
           command: EDITOR_MENU_RUN_DEBUG,
           title: 'Run Install',
           arguments: [projectPath, createNpmCommand('install')],
-        },
-        editorTitleRunDebugCommandId
+        }
       );
       return;
     }
@@ -44,19 +40,18 @@ export default async function createEditorMenuAction(terminals: ITerminalMap) {
       title: 'Run Build',
       arguments: [projectPath, createNpmCommand('run', 'build')],
     };
-    const commandId = editorTitleRunBuildCommandId;
     if (!pathExists) {
       command.arguments = [projectPath, `${createNpmCommand('install')} && ${command.arguments![1]}`];
-      executeCommand(terminals, command, commandId);
+      executeCommand(command);
       return;
     }
-    executeCommand(terminals, command, commandId);
+    executeCommand(command);
   });
 
   const isAliInternal = await checkIsAliInternal();
   if (isAliInternal) {
     registerCommand('iceworksApp.editorMenu.DefPublish', () => {
-      showDefPublishEnvQuickPick(terminals);
+      showDefPublishEnvQuickPick();
     });
   }
 }

--- a/extensions/iceworks-app/src/extension.ts
+++ b/extensions/iceworks-app/src/extension.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { Terminal, window, ViewColumn } from 'vscode';
+import { window, ViewColumn } from 'vscode';
 import { connectService, getHtmlForWebview } from '@iceworks/vscode-webview/lib/vscode';
 import { getProjectType } from '@iceworks/project-service';
 import { Recorder, recordDAU } from '@iceworks/recorder';
@@ -9,7 +9,6 @@ import { createNodeDependenciesTreeView } from './views/nodeDependenciesView';
 import { createComponentsTreeView } from './views/componentsView';
 import { createPagesTreeView } from './views/pagesView';
 import { createQuickEntriesTreeView } from './views/quickEntriesView';
-import { ITerminalMap } from './types';
 import services from './services';
 import { showExtensionsQuickPickCommandId } from './constants';
 import showEntriesQuickPick from './quickPicks/showEntriesQuickPick';
@@ -74,10 +73,6 @@ export async function activate(context: vscode.ExtensionContext) {
 
   // init tree view
   const treeViews: any[] = [];
-  // const terminals: ITerminalMap = new Map<string, Terminal>();
-  // window.onDidCloseTerminal((terminal) => {
-  //   terminals.delete(terminal.name);
-  // });
 
   treeViews.push(createQuickEntriesTreeView(context));
   treeViews.push(createNpmScriptsTreeView(context));

--- a/extensions/iceworks-app/src/extension.ts
+++ b/extensions/iceworks-app/src/extension.ts
@@ -74,16 +74,16 @@ export async function activate(context: vscode.ExtensionContext) {
 
   // init tree view
   const treeViews: any[] = [];
-  const terminals: ITerminalMap = new Map<string, Terminal>();
-  window.onDidCloseTerminal((terminal) => {
-    terminals.delete(terminal.name);
-  });
+  // const terminals: ITerminalMap = new Map<string, Terminal>();
+  // window.onDidCloseTerminal((terminal) => {
+  //   terminals.delete(terminal.name);
+  // });
 
   treeViews.push(createQuickEntriesTreeView(context));
-  treeViews.push(createNpmScriptsTreeView(context, terminals));
+  treeViews.push(createNpmScriptsTreeView(context));
   treeViews.push(createComponentsTreeView(context));
   treeViews.push(createPagesTreeView(context));
-  treeViews.push(createNodeDependenciesTreeView(context, terminals));
+  treeViews.push(createNodeDependenciesTreeView(context));
   let didSetViewContext;
   treeViews.forEach((treeView) => {
     const { title } = treeView;
@@ -110,6 +110,6 @@ export async function activate(context: vscode.ExtensionContext) {
   if (projectType !== 'unknown') {
     vscode.commands.executeCommand('setContext', 'iceworks:isAliInternal', await checkIsAliInternal());
     vscode.commands.executeCommand('setContext', 'iceworks:showScriptIconInEditorTitleMenu', true);
-    await createEditorMenuAction(terminals);
+    await createEditorMenuAction();
   }
 }

--- a/extensions/iceworks-app/src/inputBoxs/showDepsInputBox.ts
+++ b/extensions/iceworks-app/src/inputBoxs/showDepsInputBox.ts
@@ -1,10 +1,9 @@
 import * as vscode from 'vscode';
-import { NodeDepTypes, ITerminalMap } from '../types';
+import { NodeDepTypes } from '../types';
 import executeCommand from '../commands/executeCommand';
 import i18n from '../i18n';
 
 export default async function showDepsInputBox(
-  terminals: ITerminalMap,
   nodeDependenciesInstance: any,
   depType: NodeDepTypes
 ) {
@@ -15,5 +14,5 @@ export default async function showDepsInputBox(
   if (!result) {
     return;
   }
-  executeCommand(terminals, nodeDependenciesInstance.getAddDependencyScript(depType, result));
+  executeCommand(nodeDependenciesInstance.getAddDependencyScript(depType, result));
 }

--- a/extensions/iceworks-app/src/inputBoxs/showDepsInputBox.ts
+++ b/extensions/iceworks-app/src/inputBoxs/showDepsInputBox.ts
@@ -3,10 +3,7 @@ import { NodeDepTypes } from '../types';
 import executeCommand from '../commands/executeCommand';
 import i18n from '../i18n';
 
-export default async function showDepsInputBox(
-  nodeDependenciesInstance: any,
-  depType: NodeDepTypes
-) {
+export default async function showDepsInputBox(nodeDependenciesInstance: any, depType: NodeDepTypes) {
   const result = await vscode.window.showInputBox({
     placeHolder: i18n.format('extension.iceworksApp.showDepsInputBox.materialImport.placeHolder'),
     prompt: i18n.format('extension.iceworksApp.showDepsInputBox.materialImport.prompt', { depType }),

--- a/extensions/iceworks-app/src/quickPicks/showDefPublishEnvQuickPick.ts
+++ b/extensions/iceworks-app/src/quickPicks/showDefPublishEnvQuickPick.ts
@@ -1,12 +1,11 @@
 import * as vscode from 'vscode';
 import { projectPath } from '@iceworks/project-service';
-import { ITerminalMap } from '../types';
 import executeCommand from '../commands/executeCommand';
 import i18n from '../i18n';
 
 const { window } = vscode;
 
-export default function showDefPublishEnvQuickPick(terminalMapping: ITerminalMap) {
+export default function showDefPublishEnvQuickPick() {
   const DEFEnvOptions = [
     {
       label: i18n.format('extension.iceworksApp.showDefPublishEnvQuickPick.DEFEnvOptions.daily.label'),
@@ -30,7 +29,7 @@ export default function showDefPublishEnvQuickPick(terminalMapping: ITerminalMap
         command: 'iceworksApp.editorMenu.DefPublish',
         arguments: [projectPath, env.command],
       };
-      executeCommand(terminalMapping, command, `DefPublish-${env.label}`);
+      executeCommand(command);
       quickPick.dispose();
     }
   });

--- a/extensions/iceworks-app/src/quickPicks/showDepsQuickPick.ts
+++ b/extensions/iceworks-app/src/quickPicks/showDepsQuickPick.ts
@@ -1,10 +1,10 @@
 import * as vscode from 'vscode';
 import { nodeDepTypes } from '../constants';
-import { NodeDepTypes, ITerminalMap } from '../types';
+import { NodeDepTypes } from '../types';
 import showDepsInputBox from '../inputBoxs/showDepsInputBox';
 import i18n from '../i18n';
 
-export default function showDepsQuickPick(terminals: ITerminalMap, nodeDependenciesInstance: any) {
+export default function showDepsQuickPick(nodeDependenciesInstance: any) {
   const quickPick = vscode.window.createQuickPick();
   quickPick.items = nodeDepTypes.map((label) => ({
     label,
@@ -12,7 +12,7 @@ export default function showDepsQuickPick(terminals: ITerminalMap, nodeDependenc
   }));
   quickPick.onDidChangeSelection((selection) => {
     if (selection[0]) {
-      showDepsInputBox(terminals, nodeDependenciesInstance, selection[0].label as NodeDepTypes).catch(console.error);
+      showDepsInputBox(nodeDependenciesInstance, selection[0].label as NodeDepTypes).catch(console.error);
     }
   });
   quickPick.onDidHide(() => quickPick.dispose());

--- a/extensions/iceworks-app/src/types.ts
+++ b/extensions/iceworks-app/src/types.ts
@@ -1,5 +1,1 @@
-import { Terminal } from 'vscode';
-
-export type ITerminalMap = Map<string, Terminal>;
-
 export type NodeDepTypes = 'dependencies' | 'devDependencies';

--- a/extensions/iceworks-app/src/views/nodeDependenciesView.ts
+++ b/extensions/iceworks-app/src/views/nodeDependenciesView.ts
@@ -216,9 +216,7 @@ export function createNodeDependenciesTreeView(context) {
   registerCommand('iceworksApp.nodeDependencies.devDependencies.add', () =>
     showDepsInputBox(nodeDependenciesProvider, 'devDependencies')
   );
-  registerCommand('iceworksApp.nodeDependencies.addDepsAndDevDeps', () =>
-    showDepsQuickPick(nodeDependenciesProvider)
-  );
+  registerCommand('iceworksApp.nodeDependencies.addDepsAndDevDeps', () => showDepsQuickPick(nodeDependenciesProvider));
 
   const pattern = new vscode.RelativePattern(path.join(projectPath, dependencyDir), '**');
   const fileWatcher = vscode.workspace.createFileSystemWatcher(pattern, false, false, false);
@@ -241,10 +239,10 @@ function toDep(
   const npmCommand = createNpmCommand(isYarn ? 'upgrade' : 'update', moduleName);
   const command = outdated
     ? {
-      command: 'iceworksApp.nodeDependencies.upgrade',
-      title: 'Upgrade Dependency',
-      arguments: [workspaceDir, npmCommand],
-    }
+        command: 'iceworksApp.nodeDependencies.upgrade',
+        title: 'Upgrade Dependency',
+        arguments: [workspaceDir, npmCommand],
+      }
     : undefined;
   return new DependencyTreeItem(
     extensionContext,

--- a/extensions/iceworks-app/src/views/nodeDependenciesView.ts
+++ b/extensions/iceworks-app/src/views/nodeDependenciesView.ts
@@ -194,30 +194,30 @@ class DependencyTreeItem extends vscode.TreeItem {
   };
 }
 
-export function createNodeDependenciesTreeView(context, terminals) {
+export function createNodeDependenciesTreeView(context) {
   const nodeDependenciesProvider = new DepNodeProvider(context, projectPath);
   const treeView = vscode.window.createTreeView('nodeDependencies', { treeDataProvider: nodeDependenciesProvider });
 
   registerCommand('iceworksApp.nodeDependencies.refresh', () => nodeDependenciesProvider.refresh());
   registerCommand('iceworksApp.nodeDependencies.upgrade', (node: DependencyTreeItem) => {
     if (node.command) {
-      executeCommand(terminals, node.command, node.id);
+      executeCommand(node.command);
     }
   });
   registerCommand('iceworksApp.nodeDependencies.reinstall', async () => {
     if (await nodeDependenciesProvider.packageJsonExists()) {
       const script = await nodeDependenciesProvider.getReinstallScript();
-      executeCommand(terminals, script!);
+      executeCommand(script);
     }
   });
   registerCommand('iceworksApp.nodeDependencies.dependencies.add', () =>
-    showDepsInputBox(terminals, nodeDependenciesProvider, 'dependencies')
+    showDepsInputBox(nodeDependenciesProvider, 'dependencies')
   );
   registerCommand('iceworksApp.nodeDependencies.devDependencies.add', () =>
-    showDepsInputBox(terminals, nodeDependenciesProvider, 'devDependencies')
+    showDepsInputBox(nodeDependenciesProvider, 'devDependencies')
   );
   registerCommand('iceworksApp.nodeDependencies.addDepsAndDevDeps', () =>
-    showDepsQuickPick(terminals, nodeDependenciesProvider)
+    showDepsQuickPick(nodeDependenciesProvider)
   );
 
   const pattern = new vscode.RelativePattern(path.join(projectPath, dependencyDir), '**');
@@ -241,10 +241,10 @@ function toDep(
   const npmCommand = createNpmCommand(isYarn ? 'upgrade' : 'update', moduleName);
   const command = outdated
     ? {
-        command: 'iceworksApp.nodeDependencies.upgrade',
-        title: 'Upgrade Dependency',
-        arguments: [workspaceDir, npmCommand],
-      }
+      command: 'iceworksApp.nodeDependencies.upgrade',
+      title: 'Upgrade Dependency',
+      arguments: [workspaceDir, npmCommand],
+    }
     : undefined;
   return new DependencyTreeItem(
     extensionContext,

--- a/extensions/iceworks-app/src/views/npmScriptsView.ts
+++ b/extensions/iceworks-app/src/views/npmScriptsView.ts
@@ -57,8 +57,8 @@ export class NpmScriptsProvider implements vscode.TreeDataProvider<ScriptTreeIte
 
       const scripts = packageJson.scripts
         ? Object.keys(packageJson.scripts).map((script) =>
-          toScript(script, packageJson.scripts[script], `npmScripts-${script}`)
-        )
+            toScript(script, packageJson.scripts[script], `npmScripts-${script}`)
+          )
         : [];
       return scripts;
     } else {

--- a/extensions/iceworks-app/src/views/npmScriptsView.ts
+++ b/extensions/iceworks-app/src/views/npmScriptsView.ts
@@ -5,7 +5,6 @@ import { createNpmCommand, checkPathExists, registerCommand } from '@iceworks/co
 import { dependencyDir, packageJSONFilename, projectPath } from '@iceworks/project-service';
 import executeCommand from '../commands/executeCommand';
 import stopCommand from '../commands/stopCommand';
-import { ITerminalMap } from '../types';
 
 export class NpmScriptsProvider implements vscode.TreeDataProvider<ScriptTreeItem> {
   private workspaceRoot: string | undefined;
@@ -58,8 +57,8 @@ export class NpmScriptsProvider implements vscode.TreeDataProvider<ScriptTreeIte
 
       const scripts = packageJson.scripts
         ? Object.keys(packageJson.scripts).map((script) =>
-            toScript(script, packageJson.scripts[script], `npmScripts-${script}`)
-          )
+          toScript(script, packageJson.scripts[script], `npmScripts-${script}`)
+        )
         : [];
       return scripts;
     } else {
@@ -88,19 +87,19 @@ export class ScriptTreeItem extends vscode.TreeItem {
   contextValue = 'script';
 }
 
-export function createNpmScriptsTreeView(context: vscode.ExtensionContext, terminals: ITerminalMap) {
+export function createNpmScriptsTreeView(context: vscode.ExtensionContext) {
   const npmScriptsProvider = new NpmScriptsProvider(context, projectPath);
   const treeView = vscode.window.createTreeView('npmScripts', { treeDataProvider: npmScriptsProvider });
 
   registerCommand('iceworksApp.npmScripts.run', async (script: ScriptTreeItem) => {
     if (!(await checkPathExists(projectPath, dependencyDir))) {
       script.command.arguments = [projectPath, `${createNpmCommand('install')} && ${script.command.arguments![1]}`];
-      executeCommand(terminals, script.command, script.id);
+      executeCommand(script.command);
       return;
     }
-    executeCommand(terminals, script.command, script.id);
+    executeCommand(script.command);
   });
-  registerCommand('iceworksApp.npmScripts.stop', (script: ScriptTreeItem) => stopCommand(terminals, script.id));
+  registerCommand('iceworksApp.npmScripts.stop', (script: ScriptTreeItem) => stopCommand(script.command));
   registerCommand('iceworksApp.npmScripts.refresh', () => npmScriptsProvider.refresh());
 
   const pattern = new vscode.RelativePattern(projectPath, packageJSONFilename);


### PR DESCRIPTION
Fix: 停止脚本功能失败

解决：
- 不再维护一份 terminalsMap，直接使用 vscode.window 提供的 terminals 数组，并对其中 terminal 进行创建、销毁。