### PR TITLE
Fix: create router page path

### DIFF
--- a/packages/page-service/package.json
+++ b/packages/page-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iceworks/page-service",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "Iceworks page service for VSCode extension.",
   "files": [
     "lib"

--- a/packages/page-service/src/index.ts
+++ b/packages/page-service/src/index.ts
@@ -22,6 +22,7 @@ import * as upperCamelCase from 'uppercamelcase';
 import * as ejs from 'ejs';
 import * as transfromTsToJs from 'transform-ts-to-js';
 import reactPageTemplate from './templates/template.react';
+import raxPageTemplate from './templates/template.rax';
 import vuePageTemplate from './templates/template.vue';
 import i18n from './i18n';
 import renderEjsTemplates from './utils/renderEjsTemplates';
@@ -56,7 +57,17 @@ export const generate = async function ({
 
     try {
       await addBlocks(blocks, pageName);
-      const fileStr = isVueProjectFramework ? vuePageTemplate : reactPageTemplate;
+
+      // get page ejs template 
+      let fileStr = '';
+      if (projectFramework === 'icejs') {
+        fileStr = reactPageTemplate;
+      } else if (projectFramework === 'vue') {
+        fileStr = vuePageTemplate;
+      } else if (projectFramework === 'rax-app') {
+        fileStr = raxPageTemplate;
+      }
+
       const fileContent = ejs.compile(fileStr)({
         blocks: blocks.map((block: any) => {
           const blockName = upperCamelCase(block.name);

--- a/packages/page-service/src/index.ts
+++ b/packages/page-service/src/index.ts
@@ -58,7 +58,7 @@ export const generate = async function ({
     try {
       await addBlocks(blocks, pageName);
 
-      // get page ejs template 
+      // get page ejs template
       let fileStr = '';
       if (projectFramework === 'icejs') {
         fileStr = reactPageTemplate;

--- a/packages/page-service/src/templates/template.rax.ts
+++ b/packages/page-service/src/templates/template.rax.ts
@@ -1,0 +1,17 @@
+const templateStr = `import { createElement } from 'rax';
+<% for(var i = 0; i < blocks.length; i++) { -%>
+import <%= blocks[i].className %> from '<%= blocks[i].relativePath -%>';
+<% } -%>
+
+export default function () {
+  return (
+    <div className="<%= pageName %>-page">
+      <% for(var i = 0; i < blocks.length; i++){ -%>
+      <% if (blocks[i].description) { %>{/* <%= blocks[i].description -%> */}<% } %>
+      <<%= blocks[i].className -%> />
+      <% } -%>
+    </div>
+  );
+}
+`;
+export default templateStr;

--- a/packages/router-service/package.json
+++ b/packages/router-service/package.json
@@ -14,7 +14,8 @@
     "@babel/types": "^7.10.5",
     "@iceworks/project-service": "^0.1.4",
     "fs-extra": "^9.0.0",
-    "prettier": "^2.1.1"
+    "prettier": "^2.1.1",
+    "uppercamelcase": "^3.0.0"
   },
   "devDependencies": {
     "@types/vscode": "^1.45.0"

--- a/packages/router-service/package.json
+++ b/packages/router-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iceworks/router-service",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Iceworks router service for VSCode extension.",
   "files": [
     "lib"

--- a/packages/router-service/src/index.ts
+++ b/packages/router-service/src/index.ts
@@ -5,6 +5,7 @@ import * as parser from '@babel/parser';
 import * as t from '@babel/types';
 import generate from '@babel/generator';
 import * as prettier from 'prettier';
+import * as upperCamelCase from 'uppercamelcase';
 import { getProjectLanguageType, projectPath, PAGE_DIRECTORY, LAYOUT_DIRECTORY } from '@iceworks/project-service';
 
 interface IRouter {
@@ -42,7 +43,7 @@ const noPathPrefix = false;
 
 export async function create(data) {
   const { path, pageName, parent } = data;
-  await bulkCreate(projectPath, [{ path, component: pageName }], { parent });
+  await bulkCreate(projectPath, [{ path, component: upperCamelCase(pageName) }], { parent });
 }
 
 export async function getAll() {

--- a/packages/router-service/src/index.ts
+++ b/packages/router-service/src/index.ts
@@ -201,6 +201,9 @@ function changeImportDeclarations(routerConfigAST, data) {
   // router import page or layout have @
   let existAtSign = false;
   let existLazy = false;
+  // React.lazy(): the existLazyPrefix is true
+  // lazy(): the existLazyPrefix is false
+  let existLazyPrefix = false;
 
   traverse(routerConfigAST, {
     ImportDeclaration: ({ node, key }) => {
@@ -235,17 +238,20 @@ function changeImportDeclarations(routerConfigAST, data) {
       const code = generate(node.declarations[0]).code;
       // parse const declaration to get directory type (layouts or pages)
       // support three path types
-      // 1. const xxx = React.lazy(() => import('pages/xxx'));
-      // 2. const xxx = React.lazy(() => import('./pages/xxx'));
-      // 3. const xxx = React.lazy(() => import('@/pages/xxx'));
-      const noPrefixReg = /(\w+)\s=\sReact\.lazy(.+)import\(['|"]((\w+)\/.+)['|"]\)/;
-      const hasPrefixReg = /(\w+)\s=\sReact\.lazy(.+)import\(['|"]((\.|@)\/(\w+)\/.+)['|"]\)/;
+      // 1. const xxx = (React.)?lazy(() => import('pages/xxx'));
+      // 2. const xxx = (React.)?lazy(() => import('./pages/xxx'));
+      // 3. const xxx = (React.)?lazy(() => import('@/pages/xxx'));
+      const noPrefixReg = /(\w+)\s=\s(React\.)?lazy(.+)import\(['|"]((\w+)\/.+)['|"]\)/;
+      const hasPrefixReg = /(\w+)\s=\s(React\.)?lazy(.+)import\(['|"]((\.|@)\/(\w+)\/.+)['|"]\)/;
       const matchLazyReg = noPathPrefix ? noPrefixReg : hasPrefixReg;
-      const idx = noPathPrefix ? 4 : 5;
+      const idx = noPathPrefix ? 5 : 6;
       const match = code.match(matchLazyReg);
 
       if (match && match.length > idx) {
         existLazy = true;
+        if (match[2]) {
+          existLazyPrefix = true;
+        }
         existAtSign = match[idx - 1] === '@';
         importDeclarations.push({
           index: key,
@@ -351,7 +357,7 @@ function changeImportDeclarations(routerConfigAST, data) {
       importCode += `import ${name} from '${sign}/${type}/${name}';\n`;
     } else {
       // use lazy `const Page = React.lazy(() => import('@/pages/Page'))`
-      lazyCode += `const ${name} = React.lazy(() => import('${sign}/${type}/${name}'));\n`;
+      lazyCode += `const ${name} = ${existLazyPrefix ? 'React.' : ''}lazy(() => import('${sign}/${type}/${name}'));\n`;
     }
   });
 


### PR DESCRIPTION
Fix:
- 使用Create Page添加 page 的时候，routes.ts 会忽略用 lazy 引入的原页面，又重新 import 了一遍
- Rax 搭建页面产物错误，出现 `import React, { Component } from 'react'; `
- 生成路由时引用的页面路径与文件夹名称大小写不一致 

Closed #506 
Closed #522 