### PR TITLE
hotfix: welcome page

### DIFF
--- a/extensions/iceworks-app/CHANGELOG.md
+++ b/extensions/iceworks-app/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.5.2
+
+- fix: if there is an active window, then do not show the welcome page
+
 ## 0.5.1
 
 - fix: show welcome page many times

--- a/extensions/iceworks-app/package.json
+++ b/extensions/iceworks-app/package.json
@@ -3,7 +3,7 @@
   "displayName": "Iceworks Application Viewer",
   "description": "Quick view your Universal Application(React/Rax/Vue, etc).",
   "publisher": "iceworks-team",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "engines": {
     "vscode": "^1.41.0"
   },

--- a/extensions/iceworks-app/src/extension.ts
+++ b/extensions/iceworks-app/src/extension.ts
@@ -163,7 +163,7 @@ export async function activate(context: vscode.ExtensionContext) {
   const isNotTargetProject = await checkIsNotTarget();
   // get showWelcomePage configuration from settings.json
   const isShowWelcomePage = await getDataFromSettingJson('showWelcomePage', true);
-  if (projectPath && !isNotTargetProject && isShowWelcomePage) {
+  if (projectPath && !isNotTargetProject && isShowWelcomePage && !vscode.window.activeTextEditor) {
     const curProjectExistsTime = getFolderExistsTime(projectPath);
     if (projectExistsTime > curProjectExistsTime) {
       vscode.commands.executeCommand('iceworksApp.welcome.start');

--- a/extensions/iceworks-app/src/extension.ts
+++ b/extensions/iceworks-app/src/extension.ts
@@ -20,7 +20,7 @@ import { showExtensionsQuickPickCommandId, projectExistsTime } from './constants
 import showEntriesQuickPick from './quickPicks/showEntriesQuickPick';
 import createEditorMenuAction from './utils/createEditorMenuAction';
 import createExtensionsStatusBar from './statusBar/createExtensionsStatusBar';
-import autoStart from './utils/autoStart';
+import autoStart, { didShowWelcomePageBySidebarStateKey } from './utils/autoStart';
 import i18n from './i18n';
 
 // eslint-disable-next-line
@@ -28,7 +28,7 @@ const { name, version } = require('../package.json');
 const recorder = new Recorder(name, version);
 
 export async function activate(context: vscode.ExtensionContext) {
-  const { subscriptions, extensionPath } = context;
+  const { subscriptions, extensionPath, globalState } = context;
 
   // auto set configuration & context
   initExtension(context, name);
@@ -148,7 +148,7 @@ export async function activate(context: vscode.ExtensionContext) {
       if (visible && !didSetViewContext) {
         didSetViewContext = true;
         recordDAU();
-        autoStart();
+        autoStart(context);
       }
     });
   });
@@ -167,6 +167,7 @@ export async function activate(context: vscode.ExtensionContext) {
     const curProjectExistsTime = getFolderExistsTime(projectPath);
     if (projectExistsTime > curProjectExistsTime) {
       vscode.commands.executeCommand('iceworksApp.welcome.start');
+      globalState.update(didShowWelcomePageBySidebarStateKey, true);
     }
   }
 }

--- a/extensions/iceworks-app/src/utils/autoStart.ts
+++ b/extensions/iceworks-app/src/utils/autoStart.ts
@@ -1,10 +1,16 @@
 import * as vscode from 'vscode';
 import { checkIsNotTarget } from '@iceworks/project-service';
+import { didShowWelcomePageStateKey } from '@iceworks/common-service';
 
-export default async function () {
+export const didShowWelcomePageBySidebarStateKey = 'iceworks.didShowWelcomePageBySidebar';
+
+export default async function (context: vscode.ExtensionContext) {
+  const { globalState } = context;
   const isNotTargetProject = await checkIsNotTarget();
-
   if (isNotTargetProject) {
     vscode.commands.executeCommand('iceworks-project-creator.start');
+  } else if (!globalState.get(didShowWelcomePageStateKey) && !globalState.get(didShowWelcomePageBySidebarStateKey)) {
+    vscode.commands.executeCommand('iceworksApp.welcome.start');
+    globalState.update(didShowWelcomePageBySidebarStateKey, true);
   }
 }

--- a/extensions/iceworks-config-helper/CHANGELOG.md
+++ b/extensions/iceworks-config-helper/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.3.5
+
+- fix: if there is an active window, then do not show the welcome page
+
 ## 0.3.4
 
 - fix: show welcome page many times

--- a/extensions/iceworks-config-helper/package.json
+++ b/extensions/iceworks-config-helper/package.json
@@ -3,7 +3,7 @@
   "displayName": "Iceworks Config Helper",
   "description": "Easily write Config files in icejs(& rax-app)",
   "publisher": "iceworks-team",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "engines": {
     "vscode": "^1.41.0"
   },

--- a/extensions/iceworks-doctor/CHANGELOG.md
+++ b/extensions/iceworks-doctor/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.1.2
+
+- fix: if there is an active window, then do not show the welcome page
+
 ## 0.1.1
 
 - docs: add logo

--- a/extensions/iceworks-doctor/package.json
+++ b/extensions/iceworks-doctor/package.json
@@ -3,7 +3,7 @@
   "displayName": "Iceworks Doctor",
   "description": "A free security and quality audit tool for modern DevOps teams",
   "publisher": "iceworks-team",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "engines": {
     "vscode": "^1.41.0"
   },

--- a/extensions/iceworks-material-helper/CHANGELOG.md
+++ b/extensions/iceworks-material-helper/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.3.8
+
+- fix: if there is an active window, then do not show the welcome page
+
 ## 0.3.7
 
 - fix: show welcome page many times

--- a/extensions/iceworks-material-helper/package.json
+++ b/extensions/iceworks-material-helper/package.json
@@ -3,7 +3,7 @@
   "displayName": "React Component Helper",
   "description": "Easily use Component in React/Rax.",
   "publisher": "iceworks-team",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "main": "./build/extension.js",
   "engines": {
     "vscode": "^1.41.0"

--- a/extensions/iceworks-project-creator/CHANGELOG.md
+++ b/extensions/iceworks-project-creator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.3.13
+
+- fix: if there is an active window, then do not show the welcome page
+
 ## 0.3.12
 
 - fix: show welcome page many times

--- a/extensions/iceworks-project-creator/package.json
+++ b/extensions/iceworks-project-creator/package.json
@@ -3,7 +3,7 @@
   "displayName": "Iceworks Application Creator",
   "description": "Quick create a Universal Application(React/Rax/Vue, etc).",
   "publisher": "iceworks-team",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "engines": {
     "vscode": "^1.41.0"
   },

--- a/extensions/iceworks-style-helper/CHANGELOG.md
+++ b/extensions/iceworks-style-helper/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.3.10
+
+- fix: if there is an active window, then do not show the welcome page
+
 ## 0.3.9
 
 - feat: Add welcome page

--- a/extensions/iceworks-style-helper/package.json
+++ b/extensions/iceworks-style-helper/package.json
@@ -3,7 +3,7 @@
   "displayName": "React Style Helper",
   "description": "Easily write styles(CSS/Less/SASS).",
   "publisher": "iceworks-team",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "engines": {
     "vscode": "^1.41.0"
   },

--- a/extensions/iceworks-time-steward/CHANGELOG.md
+++ b/extensions/iceworks-time-steward/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.1.4
+
+- fix: if there is an active window, then do not show the welcome page
+
 ## 0.1.3
 
 - feat: Add welcome page

--- a/extensions/iceworks-time-steward/package.json
+++ b/extensions/iceworks-time-steward/package.json
@@ -3,7 +3,7 @@
   "displayName": "Iceworks Time Steward(Beta)",
   "description": "Metrics, insights, and time tracking automatically generated from your programming activity.",
   "publisher": "iceworks-team",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "engines": {
     "vscode": "^1.41.0"
   },

--- a/extensions/iceworks-ui-builder/CHANGELOG.md
+++ b/extensions/iceworks-ui-builder/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.1.17
+
+- fix: if there is an active window, then do not show the welcome page
+
 ## 0.1.16
 
 - fix: show welcome page many times

--- a/extensions/iceworks-ui-builder/package.json
+++ b/extensions/iceworks-ui-builder/package.json
@@ -3,7 +3,7 @@
   "displayName": "Iceworks UI Builder",
   "description": "Build UI by low-code way",
   "publisher": "iceworks-team",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "engines": {
     "vscode": "^1.41.0"
   },

--- a/packages/common-service/package.json
+++ b/packages/common-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iceworks/common-service",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "description": "Iceworks common service for VSCode extension.",
   "files": [
     "lib"

--- a/packages/common-service/src/index.ts
+++ b/packages/common-service/src/index.ts
@@ -119,6 +119,7 @@ export const didShowWelcomePageStateKey = 'iceworks.didShowWelcomePage';
 async function autoStartWelcomePage(globalState: vscode.Memento) {
   const didShowWelcomePage = globalState.get(didShowWelcomePageStateKey);
 
+  // if didSetMaterialSource means is installed
   const isFirstInstall = !didShowWelcomePage && !globalState.get(didSetMaterialSourceStateKey);
   if (isFirstInstall && !vscode.window.activeTextEditor && vscode.extensions.getExtension('iceworks-team.iceworks-app')) {
     vscode.commands.executeCommand('iceworksApp.welcome.start');

--- a/packages/common-service/src/index.ts
+++ b/packages/common-service/src/index.ts
@@ -119,7 +119,7 @@ async function autoStartWelcomePage(globalState: vscode.Memento) {
   const globalStateKey = 'iceworks.didShowWelcomePage';
   const didShowWelcomePage = globalState.get(globalStateKey);
   // first install Iceworks and iceworks-app exists, show welcome page
-  if (!didShowWelcomePage && vscode.extensions.getExtension('iceworks-team.iceworks-app')) {
+  if (!didShowWelcomePage && !vscode.window.activeTextEditor && vscode.extensions.getExtension('iceworks-team.iceworks-app')) {
     vscode.commands.executeCommand('iceworksApp.welcome.start');
   }
   globalState.update(globalStateKey, true);

--- a/packages/common-service/src/index.ts
+++ b/packages/common-service/src/index.ts
@@ -115,14 +115,15 @@ async function autoSetContext() {
   vscode.commands.executeCommand('setContext', 'iceworks:isAliInternal', await checkIsAliInternal());
 }
 
+const didShowWelcomePageStateKey = 'iceworks.didShowWelcomePage';
 async function autoStartWelcomePage(globalState: vscode.Memento) {
-  const globalStateKey = 'iceworks.didShowWelcomePage';
-  const didShowWelcomePage = globalState.get(globalStateKey);
-  // first install Iceworks and iceworks-app exists, show welcome page
-  if (!didShowWelcomePage && !vscode.window.activeTextEditor && vscode.extensions.getExtension('iceworks-team.iceworks-app')) {
+  const didShowWelcomePage = globalState.get(didShowWelcomePageStateKey);
+
+  const isFirstInstall = !didShowWelcomePage && !globalState.get(didSetMaterialSourceStateKey);
+  if (isFirstInstall && !vscode.window.activeTextEditor && vscode.extensions.getExtension('iceworks-team.iceworks-app')) {
     vscode.commands.executeCommand('iceworksApp.welcome.start');
   }
-  globalState.update(globalStateKey, true);
+  globalState.update(didShowWelcomePageStateKey, true);
 }
 
 function onChangeActiveTextEditor(context: vscode.ExtensionContext) {
@@ -143,11 +144,9 @@ function onChangeActiveTextEditor(context: vscode.ExtensionContext) {
     context.subscriptions
   );
 }
-
+const didSetMaterialSourceStateKey = 'iceworks.materialSourceIsSet';
 async function autoInitMaterialSource(globalState: vscode.Memento) {
-  console.log('autoInitMaterialSource: run');
-  const stateKey = 'iceworks.materialSourceIsSet';
-  const materialSourceIsSet = globalState.get(stateKey);
+  const materialSourceIsSet = globalState.get(didSetMaterialSourceStateKey);
   if (!materialSourceIsSet) {
     console.log('autoInitMaterialSource: do');
     const materialSources = getDataFromSettingJson(CONFIGURATION_KEY_MATERIAL_SOURCES);
@@ -167,7 +166,7 @@ async function autoInitMaterialSource(globalState: vscode.Memento) {
     if (isTrue) {
       console.log('autoSetPackageManager: did change');
 
-      globalState.update(stateKey, true);
+      globalState.update(didSetMaterialSourceStateKey, true);
     }
   });
 }

--- a/packages/common-service/src/index.ts
+++ b/packages/common-service/src/index.ts
@@ -115,7 +115,7 @@ async function autoSetContext() {
   vscode.commands.executeCommand('setContext', 'iceworks:isAliInternal', await checkIsAliInternal());
 }
 
-const didShowWelcomePageStateKey = 'iceworks.didShowWelcomePage';
+export const didShowWelcomePageStateKey = 'iceworks.didShowWelcomePage';
 async function autoStartWelcomePage(globalState: vscode.Memento) {
   const didShowWelcomePage = globalState.get(didShowWelcomePageStateKey);
 


### PR DESCRIPTION
调整和修复展示欢迎页的逻辑：

- 只要当前有活跃的编辑窗口，就不弹出（无论其他任何条件）
- 只有首次安装完 Iceworks 才主动弹出
- 第一次点击图标时，弹出（排除了安装完弹出的逻辑）
- 每次创建应用完成，弹出