### PR TITLE
Fix eslint plugin dependencies use wrong path

### DIFF
--- a/packages/doctor/package.json
+++ b/packages/doctor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@iceworks/doctor",
   "description": "Analyse react/rax projects, troubleshooting and automatically fixing errors",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "keywords": [
     "doctor",
     "analysis",

--- a/packages/doctor/src/getEslintReports.ts
+++ b/packages/doctor/src/getEslintReports.ts
@@ -21,7 +21,8 @@ export default function getEslintReports(files: IFileInfo[], ruleKey: string, cu
 
   const cliEngine = new CLIEngine({
     baseConfig: deepmerge(getESLintConfig(ruleKey), customConfig),
-    cwd: __dirname,
+    // Use plugin in @iceworks/spec
+    cwd: require.resolve('@iceworks/spec'),
     fix: !!fix,
     useEslintrc: false,
   });


### PR DESCRIPTION
用户老项目有相关 plugin 依赖时，eslint 找到的 plugin 会寻此地址。

更新为 @iceworks/spec 的位置，可以确保使用的都是 @iceworks/spec 指定的 plugin 和 parser.
