### PR TITLE
Feat upgrade preview

### DIFF
--- a/extensions/iceworks-app/CHANGELOG.md
+++ b/extensions/iceworks-app/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Change Log
+# 0.7.1
+
+- feat: preview support read rax dev server start urls info
+- feat: add preview command
 
 # 0.7.0
 

--- a/extensions/iceworks-app/package.json
+++ b/extensions/iceworks-app/package.json
@@ -3,7 +3,7 @@
   "displayName": "Application Explorer",
   "description": "Quick view your Universal Application(React/Rax/Vue, etc).",
   "publisher": "iceworks-team",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "engines": {
     "vscode": "^1.41.0"
   },
@@ -185,6 +185,10 @@
       {
         "command": "iceworksApp.pages.openFile",
         "title": "%iceworksApp.command.pages.openFile.title%"
+      },
+      {
+        "command": "iceworksApp.preview.open",
+        "title": "%iceworksApp.command.preview.open.title%"
       },
       {
         "command": "iceworksApp.pages.delete",

--- a/extensions/iceworks-app/package.nls.json
+++ b/extensions/iceworks-app/package.nls.json
@@ -10,6 +10,7 @@
   "iceworksApp.viewsWelcome.components.contents": "Components could not be found",
   "iceworksApp.viewsWelcome.nodeDependencies.contents": "Node dependencies could not be found in package.json",
   "iceworksApp.command.configHelper.start.title": "Iceworks: Settings",
+  "iceworksApp.command.preview.open.title": "Iceworks: Preview",
   "iceworksApp.command.welcome.start.title": "Iceworks: Welcome",
   "iceworksApp.command.DefPublish.title": "Iceworks: Def Publish",
   "iceworksApp.command.quickEntries.start.title": "Start",

--- a/extensions/iceworks-app/package.nls.zh-cn.json
+++ b/extensions/iceworks-app/package.nls.zh-cn.json
@@ -10,6 +10,7 @@
   "iceworksApp.viewsWelcome.components.contents": "未找到组件",
   "iceworksApp.viewsWelcome.nodeDependencies.contents": "未找到依赖",
   "iceworksApp.command.configHelper.start.title": "Iceworks: 设置",
+  "iceworksApp.command.preview.open.title": "Iceworks: 预览",
   "iceworksApp.command.welcome.start.title": "Iceworks: 欢迎",
   "iceworksApp.command.DefPublish.title": "Iceworks: DEF 发布",
   "iceworksApp.command.quickEntries.start.title": "启动",

--- a/extensions/iceworks-app/src/locales/en-US.json
+++ b/extensions/iceworks-app/src/locales/en-US.json
@@ -37,6 +37,8 @@
   "extension.iceworksApp.showDefPublishEnvQuickPick.DEFEnvOptions.daily.detail": "Release to daily environment.",
   "extension.iceworksApp.showDefPublishEnvQuickPick.DEFEnvOptions.prod.label": "Production",
   "extension.iceworksApp.showDefPublishEnvQuickPick.DEFEnvOptions.prod.detail": "Release to production environment.",
+  "extension.iceworksApp.showEntriesQuickPick.preview.label": "Preview",
+  "extension.iceworksApp.showEntriesQuickPick.preview.detail": "Preview Web page",
   "extension.iceworksApp.showDepsQuickPick.quickPickItem.detail": "Install <%= label %>",
   "extension.iceworksApp.openEntryFile.ErrorMessage": "Cannot find entry",
   "extension.iceworksApp.configHelper.extension.webviewTitle": "Settings - Iceworks",

--- a/extensions/iceworks-app/src/locales/zh-CN.json
+++ b/extensions/iceworks-app/src/locales/zh-CN.json
@@ -37,6 +37,8 @@
   "extension.iceworksApp.showDefPublishEnvQuickPick.DEFEnvOptions.daily.detail": "发布到日常环境",
   "extension.iceworksApp.showDefPublishEnvQuickPick.DEFEnvOptions.prod.label": "生产环境",
   "extension.iceworksApp.showDefPublishEnvQuickPick.DEFEnvOptions.prod.detail": "发布到生产环境",
+  "extension.iceworksApp.showEntriesQuickPick.preview.label": "启动预览页",
+  "extension.iceworksApp.showEntriesQuickPick.preview.detail": "在 VS Code 中预览 web 页面",
   "extension.iceworksApp.showDepsQuickPick.quickPickItem.detail": "安装 <%= label %>",
   "extension.iceworksApp.openEntryFile.ErrorMessage": "没有找到入口",
   "extension.iceworksApp.configHelper.extension.webviewTitle": "设置 - Iceworks",

--- a/extensions/iceworks-app/src/quickPicks/options.ts
+++ b/extensions/iceworks-app/src/quickPicks/options.ts
@@ -122,6 +122,11 @@ export default [
     },
   },
   {
+    label: i18n.format('extension.iceworksApp.showEntriesQuickPick.preview.label'),
+    detail: i18n.format('extension.iceworksApp.showEntriesQuickPick.preview.detail'),
+    command: 'iceworksApp.preview.open',
+  },
+  {
     label: i18n.format('extension.iceworksApp.showEntriesQuickPick.welcomePage.label'),
     detail: i18n.format('extension.iceworksApp.showEntriesQuickPick.welcomePage.detail'),
     command: 'iceworksApp.welcome.start',

--- a/extensions/iceworks-app/src/utils/createEditorMenuAction.ts
+++ b/extensions/iceworks-app/src/utils/createEditorMenuAction.ts
@@ -1,7 +1,10 @@
+import * as fs from 'fs-extra';
+import * as path from 'path';
 import * as vscode from 'vscode';
 import { createNpmCommand, checkPathExists, checkIsAliInternal, registerCommand } from '@iceworks/common-service';
-import { dependencyDir, getProjectFramework, projectPath } from '@iceworks/project-service';
+import { checkIsPegasusProject, dependencyDir, getProjectFramework, projectPath } from '@iceworks/project-service';
 import { connectService, getHtmlForWebview } from '@iceworks/vscode-webview/lib/vscode';
+import { DEFAULT_START_URL, IDevServerStartInfo, getDevServerStartInfo } from './getDevServerStartInfo';
 import services from '../services';
 import showDefPublishEnvQuickPick from '../quickPicks/showDefPublishEnvQuickPick';
 import executeCommand from '../commands/executeCommand';
@@ -9,8 +12,36 @@ import executeCommand from '../commands/executeCommand';
 let previewWebviewPanel: vscode.WebviewPanel | undefined;
 
 export default async function createEditorMenuAction(context: vscode.ExtensionContext, recorder) {
+  const { window } = vscode;
+  const { extensionPath } = context;
+
+  function openPreview(startInfo?: IDevServerStartInfo) {
+    if (previewWebviewPanel) {
+      previewWebviewPanel.reveal();
+    }
+
+    previewWebviewPanel = window.createWebviewPanel('iceworks', 'Preview', vscode.ViewColumn.Two, {
+      enableScripts: true,
+      retainContextWhenHidden: true,
+    });
+
+    const extraHtml = `<script>window.__PREVIEW__DATA__ = ${JSON.stringify(startInfo || { startUrl: DEFAULT_START_URL })};</script>`;
+
+    previewWebviewPanel.webview.html = getHtmlForWebview(extensionPath, 'preview', false, undefined, extraHtml);
+    previewWebviewPanel.onDidDispose(
+      () => {
+        previewWebviewPanel = undefined;
+      },
+      null,
+      context.subscriptions,
+    );
+    connectService(previewWebviewPanel, context, { services, recorder });
+  }
+
   const EDITOR_MENU_RUN_DEBUG = 'iceworksApp.editorMenu.runDebug';
   registerCommand(EDITOR_MENU_RUN_DEBUG, async () => {
+    const isPegasusProject = await checkIsPegasusProject();
+
     // Check dependences
     if (!(await checkPathExists(projectPath, dependencyDir))) {
       vscode.window.showInformationMessage('"node_modules" directory not found! Install dependencies first.');
@@ -22,51 +53,35 @@ export default async function createEditorMenuAction(context: vscode.ExtensionCo
       return;
     }
 
+    // npm run start.
+    // Debug in VS Code move to iceworks docs.
+    executeCommand({
+      command: EDITOR_MENU_RUN_DEBUG,
+      title: 'Run Start',
+      arguments: [projectPath, createNpmCommand('run', 'start')],
+    });
+
     if (await getProjectFramework() === 'rax-app') {
-      // Rax project preview
-      const { window } = vscode;
-      const { extensionPath } = context;
-
-      executeCommand({
-        command: EDITOR_MENU_RUN_DEBUG,
-        title: 'Run Start',
-        arguments: [projectPath, createNpmCommand('run', 'start', '-- --disable-open')],
-      });
-
-      setTimeout(() => {
-        if (previewWebviewPanel) {
-          previewWebviewPanel.reveal();
+      const devServerStartInfo: IDevServerStartInfo = await getDevServerStartInfo(projectPath);
+      openPreview(devServerStartInfo);
+    } else if (isPegasusProject) {
+      // Set pegasus service url
+      try {
+        const abcConfigFile = path.join(projectPath, 'abc.json');
+        if (fs.existsSync(abcConfigFile)) {
+          const abcConfig = fs.readJSONSync(abcConfigFile);
+          if (abcConfig.type === 'pegasus' && abcConfig.group && abcConfig.name) {
+            openPreview({ startUrl: `${DEFAULT_START_URL}${abcConfig.group}/${abcConfig.name}` });
+          }
         }
-
-        previewWebviewPanel = window.createWebviewPanel('iceworks', 'Preview', vscode.ViewColumn.Two, {
-          enableScripts: true,
-          retainContextWhenHidden: true,
-        });
-
-        const extraHtml = `<script>
-          window.__PREVIEW__DATA__ = { startUrl: 'http://localhost:3333/' };
-        </script>
-        `;
-        previewWebviewPanel.webview.html = getHtmlForWebview(extensionPath, 'preview', false, undefined, extraHtml);
-        previewWebviewPanel.onDidDispose(
-          () => {
-            previewWebviewPanel = undefined;
-          },
-          null,
-          context.subscriptions,
-        );
-        connectService(previewWebviewPanel, context, { services, recorder });
-      }, 5000);
-    } else {
-      // npm run start.
-      // Debug in VS Code move to iceworks docs.
-      executeCommand({
-        command: EDITOR_MENU_RUN_DEBUG,
-        title: 'Run Start',
-        arguments: [projectPath, createNpmCommand('run', 'start')],
-      });
+      } catch (e) {
+        // ignore
+      }
     }
   });
+
+  const PREVIEW_OPEN = 'iceworksApp.preview.open';
+  registerCommand(PREVIEW_OPEN, openPreview);
 
   const EDITOR_MENU_RUN_BUILD = 'iceworksApp.editorMenu.runBuild';
   registerCommand(EDITOR_MENU_RUN_BUILD, async () => {

--- a/extensions/iceworks-app/src/utils/createEditorMenuAction.ts
+++ b/extensions/iceworks-app/src/utils/createEditorMenuAction.ts
@@ -71,7 +71,9 @@ export default async function createEditorMenuAction(context: vscode.ExtensionCo
         if (fs.existsSync(abcConfigFile)) {
           const abcConfig = fs.readJSONSync(abcConfigFile);
           if (abcConfig.type === 'pegasus' && abcConfig.group && abcConfig.name) {
-            openPreview({ startUrl: `${DEFAULT_START_URL}${abcConfig.group}/${abcConfig.name}` });
+            setTimeout(() => {
+              openPreview({ startUrl: `${DEFAULT_START_URL}${abcConfig.group}/${abcConfig.name}` });
+            }, 10000);
           }
         }
       } catch (e) {

--- a/extensions/iceworks-app/src/utils/getDevServerStartInfo.ts
+++ b/extensions/iceworks-app/src/utils/getDevServerStartInfo.ts
@@ -1,0 +1,94 @@
+import * as fs from 'fs-extra';
+import * as path from 'path';
+
+// rax-app and ice.js will write dev server info in 'node_modules/.tmp/@builder/dev.json'.
+// Example:
+// {
+//   urls: {
+//     web: [
+//       'http://30.10.80.34:3333/',
+//     ],
+//     kraken: [
+//       'http://30.10.80.34:3333/kraken/index.js',
+//       'http://30.10.80.34:3333/kraken/index.js',
+//     ],
+//   },
+//   publicPath: '/',
+//   compiledTime: 1607744710376,
+// }
+
+export const DEFAULT_START_URL = 'http://localhost:3333/';
+
+const DEV_INFO_FILE = 'node_modules/.tmp/@builder/dev.json';
+
+const TIMEOUT = 60000;
+const READER_INTERVAL = 100;
+// Temp file valid time(compare to the 'compiledTime'). If over 5 minutes might read the old file.
+const MAX_VALID_INTERVAL = 300000;
+
+const DEFAULT_DEV_INFO = {
+  urls: {
+    web: [DEFAULT_START_URL],
+  },
+};
+
+function getDevInfo(root: string) {
+  let devInfo = null;
+  const tempFilePath = path.join(root, DEV_INFO_FILE);
+  try {
+    devInfo = JSON.parse(fs.readFileSync(tempFilePath, 'utf-8'));
+  } catch (e) {
+    // ignore
+  }
+  return devInfo;
+}
+
+function checkTempFileValid(devInfo: any) {
+  let valid = false;
+  if (devInfo && (Date.now() - devInfo.compiledTime) < MAX_VALID_INTERVAL) {
+    valid = true;
+  }
+  return valid;
+}
+
+export interface IDevServerStartInfo {
+  startUrl: string;
+  startQRCodeInfo?: any;
+}
+
+export async function getDevServerStartInfo(root: string): Promise<IDevServerStartInfo> {
+  let timerTimeout;
+  let timerReader;
+
+  const timeoutPromise = new Promise((resolve) => {
+    timerTimeout = setTimeout(resolve, TIMEOUT, DEFAULT_DEV_INFO);
+  });
+
+  const readerPromise = new Promise((resolve) => {
+    timerReader = setInterval(() => {
+      const devInfo = getDevInfo(root);
+      if (checkTempFileValid(devInfo)) {
+        resolve(devInfo);
+      }
+    }, READER_INTERVAL);
+  });
+
+  const devInfo: any = await Promise.race([timeoutPromise, readerPromise]);
+
+  clearTimeout(timerTimeout);
+  clearInterval(timerReader);
+
+  const devServerStartInfo = {
+    startUrl: DEFAULT_START_URL,
+    startQRCodeInfo: {},
+  };
+
+  if (devInfo && devInfo.urls) {
+    devServerStartInfo.startQRCodeInfo = devInfo.urls;
+    if (devInfo.urls.web && devInfo.urls.web[0]) {
+      devServerStartInfo.startUrl = devInfo.urls.web[0];
+    }
+  }
+
+  return devServerStartInfo;
+}

--- a/extensions/iceworks-app/web/src/pages/Preview/components/QRCodeWrap/index.tsx
+++ b/extensions/iceworks-app/web/src/pages/Preview/components/QRCodeWrap/index.tsx
@@ -6,22 +6,50 @@ interface IProps {
   url: string
 }
 
+// Don't show MiniApp urls
+const KEY_MAP = {
+  web: { title: 'Web' }, // Primary key
+  kraken: { title: 'Kraken' },
+  weex: { title: 'Weex' },
+};
+
+function getCurrentQRCodeInfo(url: string) {
+  const currentQRCodeInfo = [];
+  const { startQRCodeInfo } = window.__PREVIEW__DATA__;
+
+  if (startQRCodeInfo) {
+    const primaryIndex = (startQRCodeInfo.web || []).findIndex(webUrl => url === webUrl);
+
+    // If web dev server url exist render QRCode
+    if (primaryIndex > -1) {
+      Object.keys(startQRCodeInfo).forEach((infoKey) => {
+        if (KEY_MAP[infoKey]) {
+          currentQRCodeInfo.push({
+            title: KEY_MAP[infoKey].title,
+            // Rax project can have different mpa targets, spa only have one preview url
+            value: startQRCodeInfo[infoKey][primaryIndex] || startQRCodeInfo[infoKey][0],
+          });
+        }
+      });
+    }
+  }
+  return currentQRCodeInfo;
+}
+
 export default function (props: IProps) {
   const { url } = props;
-  const { startUrl, startQRCodeInfo } = window.__PREVIEW__DATA__;
+  const currentQRCodeInfo = getCurrentQRCodeInfo(url);
 
   return (
     <div className={styles.container}>
-      {startUrl === url && startQRCodeInfo ? (
-        Object.keys(startQRCodeInfo).map((title) => {
-          return (
-            <div className={styles.wrap}>
-              <h3>{title}：</h3>
-              <QRCode value={startQRCodeInfo[title]} />
-            </div>
-          );
-        })
-      ) : <QRCode value={url} />}
+      { currentQRCodeInfo.length > 0 ? (currentQRCodeInfo.map((QRCodeInfo) => {
+        return (
+          <div className={styles.wrap} key={QRCodeInfo.title}>
+            <h3>{QRCodeInfo.title}：</h3>
+            <QRCode value={QRCodeInfo.value} />
+          </div>
+        );
+      })) : <QRCode value={url} />}
     </div>
   );
 }

--- a/extensions/iceworks-app/web/src/pages/Preview/index.module.scss
+++ b/extensions/iceworks-app/web/src/pages/Preview/index.module.scss
@@ -1,6 +1,7 @@
 body {
   margin: 0;
   background-color: #fff;
+  overflow: hidden;
 }
 
 .container {

--- a/extensions/iceworks-app/web/src/pages/Preview/index.tsx
+++ b/extensions/iceworks-app/web/src/pages/Preview/index.tsx
@@ -10,11 +10,11 @@ if (!window.__PREVIEW__DATA__) {
 
 // Example：
 // window.__PREVIEW__DATA__ = {
-//   startUrl: ' http://xx.xx.xx.xx:3333/',
+//   startUrl: 'http://xx.xx.xx.xx:3333/',
 //   startQRCodeInfo: {
-//     Web: 'http://xx.xx.xx.xx:3333/',
-//     Weex: 'http://xx.xx.xx.xx:3333/weex/index.js?wh_weex=true',
-//     Kraken: 'http://xx.xx.xx.xx:3333/kraken/index.js',
+//     web: ['http://xx.xx.xx.xx:3333/', 'http://xx.xx.xx.xx:3333/home', 'http://xx.xx.xx.xx:3333/detail'],
+//     weex: ['http://xx.xx.xx.xx:3333/weex/index.js?wh_weex=true'],
+//     kraken: ['http://xx.xx.xx.xx:3333/kraken/index.js'],
 //   },
 // };
 


### PR DESCRIPTION
升级 Iceworks 预览功能：
1. 支持读取框架写入的启动 urls，超时1分钟，临时文件有效期5分钟。
2. 更新二维码展示逻辑，支持单页多页及 url 动态更新等各类情况对应展示。
3. 新增 preview 命令，并加入快捷命令中。
4. 支持天马工程预览。