### PR TITLE
Feat support analyse languages

### DIFF
--- a/packages/doctor/bin/iceworks-doctor
+++ b/packages/doctor/bin/iceworks-doctor
@@ -41,7 +41,7 @@ if (args.scan) {
   const doctor = new Doctor(args);
   doctor.scan(args.scan, {
     framework: args.framework,
-    languageType: args.languageType || 'js'
+    languageType: args.languageType || 'js',
   }).then((result) => {
     console.log({
       files: {
@@ -85,8 +85,7 @@ if (args.codemod) {
     spawnSync('jscodeshift', transformerArgs,
       {
         stdio: 'inherit',
-        stripEof: false
-      }
-    );
+        stripEof: false,
+      });
   }
 }

--- a/packages/doctor/package.json
+++ b/packages/doctor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@iceworks/doctor",
   "description": "Analyse and running codemods over react/rax projects, troubleshooting and automatically fixing errors",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "keywords": [
     "doctor",
     "analysis",

--- a/packages/doctor/src/Analyzer.ts
+++ b/packages/doctor/src/Analyzer.ts
@@ -1,0 +1,48 @@
+import * as path from 'path';
+import { IAnalyzerOptions, IAnalyzerReport } from './types/Analyzer';
+import { IFileInfo } from './types/File';
+import getFiles from './getFiles';
+
+const LANGUAGE_MAP = {
+  '.html': 'HTML',
+  '.js': 'JavaScript',
+  '.jsx': 'JavaScript',
+  '.ts': 'TypeScript',
+  '.tsx': 'TypeScript',
+  '.css': 'CSS',
+  '.scss': 'SASS',
+  '.less': 'Less',
+  '.md': 'Markdown',
+  '.json': 'JSON',
+};
+
+const UNKNOWN_LANGUAGE = 'Other';
+
+export default class Analyzer {
+  public options: IAnalyzerOptions;
+
+  constructor(options: IAnalyzerOptions) {
+    this.options = options;
+  }
+
+  public analyse(directory: string): IAnalyzerReport {
+    const report = { languages: [] };
+    const languageCache = {};
+    const files: IFileInfo[] = getFiles(directory, null, this.options.ignore);
+
+    files.forEach((file: IFileInfo) => {
+      const language = LANGUAGE_MAP[path.extname(file.path)] || UNKNOWN_LANGUAGE;
+      if (!languageCache[language]) {
+        languageCache[language] = { language, count: 1 };
+      } else {
+        languageCache[language].count++;
+      }
+    });
+
+    Object.keys(languageCache).forEach((key) => {
+      report.languages.push(languageCache[key]);
+    });
+
+    return report;
+  }
+}

--- a/packages/doctor/src/Scanner.ts
+++ b/packages/doctor/src/Scanner.ts
@@ -1,6 +1,7 @@
 import * as path from 'path';
 import Timer from './Timer';
-import { IScannerOptions, IScanOptions, IFileInfo, IScannerReports } from './types/Scanner';
+import { IScannerOptions, IScanOptions, IScannerReports } from './types/Scanner';
+import { IFileInfo } from './types/File';
 import getCustomESLintConfig from './getCustomESLintConfig';
 import getEslintReports from './getEslintReports';
 import getMaintainabilityReports from './getMaintainabilityReports';

--- a/packages/doctor/src/getEslintReports.ts
+++ b/packages/doctor/src/getEslintReports.ts
@@ -3,7 +3,8 @@ import { CLIEngine } from 'eslint';
 import { deepmerge, getESLintConfig } from '@iceworks/spec';
 import Scorer from './Scorer';
 import Timer from './Timer';
-import { IFileInfo, IEslintReports } from './types/Scanner';
+import { IEslintReports } from './types/Scanner';
+import { IFileInfo } from './types/File';
 
 // level waring minus 1 point
 const WARNING_WEIGHT = -1;

--- a/packages/doctor/src/getFiles.ts
+++ b/packages/doctor/src/getFiles.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs-extra';
 import * as path from 'path';
 import ignore from 'ignore';
 import { glob } from 'glob';
-import { IFileInfo } from './types/Scanner';
+import { IFileInfo } from './types/File';
 
 // Supprot check file's max LoC
 const MAX_CHECK_LOC = 3000;
@@ -25,7 +25,7 @@ function getFileInfo(filePath: string): IFileInfo {
   };
 }
 
-export default function getFiles(directory: string, supportExts: string[], ignoreDirs?: string[]): IFileInfo[] {
+export default function getFiles(directory: string, supportExts?: string[], ignoreDirs?: string[]): IFileInfo[] {
   const options: any = {
     nodir: true,
   };
@@ -53,8 +53,13 @@ export default function getFiles(directory: string, supportExts: string[], ignor
       }
     });
 
+    let globPattern = `${directory}/**/*`;
+    if (supportExts) {
+      globPattern = `${directory}/**/*.+(${supportExts.join('|')})`;
+    }
+
     // https://www.npmjs.com/package/glob
-    return glob.sync(`${directory}/**/*.+(${supportExts.join('|')})`, options)
+    return glob.sync(globPattern, options)
       .map(getFileInfo)
       .filter((file) => {
         // https://www.npmjs.com/package/ignore

--- a/packages/doctor/src/getMaintainabilityReports.ts
+++ b/packages/doctor/src/getMaintainabilityReports.ts
@@ -1,7 +1,8 @@
 import * as escomplex from 'typhonjs-escomplex';
 import Scorer from './Scorer';
 import Timer from './Timer';
-import { IFileInfo, IMaintainabilityReport, IMaintainabilityReports } from './types/Scanner';
+import { IMaintainabilityReport, IMaintainabilityReports } from './types/Scanner';
+import { IFileInfo } from './types/File';
 
 // https://www.npmjs.com/package/typhonjs-escomplex
 export default function getMaintainabilityReports(timer: Timer, files: IFileInfo[]): IMaintainabilityReports {

--- a/packages/doctor/src/index.ts
+++ b/packages/doctor/src/index.ts
@@ -1,7 +1,9 @@
 import getFiles from './getFiles';
+import Analyzer from './Analyzer';
 import Scanner from './Scanner';
 import { IDoctorOptions } from './types/Doctor';
-import { IFileInfo, IScanOptions, IScannerReports } from './types/Scanner';
+import { IScanOptions, IScannerReports } from './types/Scanner';
+import { IFileInfo } from './types/File';
 
 // Ignore directories
 const defaultignore = ['build', 'es', 'dist', 'lib', 'mocks', 'coverage', 'node_modules', 'demo', 'examples', 'public', 'test', '__tests__'];
@@ -17,6 +19,8 @@ class Doctor {
 
   private scanner: any;
 
+  private analyzer: any;
+
   constructor(options: IDoctorOptions) {
     this.options = options || {};
 
@@ -27,10 +31,16 @@ class Doctor {
       ignore: this.ignore,
       supportExts: this.supportExts,
     });
+
+    this.analyzer = new Analyzer({ ignore: this.ignore });
   }
 
   scan(directory: string, options?: IScanOptions): Promise<IScannerReports> {
     return this.scanner.scan(directory, options);
+  }
+
+  analyse(directory: string) {
+    this.analyzer.analyse(directory);
   }
 
   getFiles(directory: string): IFileInfo[] {

--- a/packages/doctor/src/index.ts
+++ b/packages/doctor/src/index.ts
@@ -40,7 +40,7 @@ class Doctor {
   }
 
   analyse(directory: string) {
-    this.analyzer.analyse(directory);
+    return this.analyzer.analyse(directory);
   }
 
   getFiles(directory: string): IFileInfo[] {

--- a/packages/doctor/src/types/Analyzer.ts
+++ b/packages/doctor/src/types/Analyzer.ts
@@ -1,0 +1,7 @@
+export interface IAnalyzerOptions {
+  ignore: string[];
+}
+
+export interface IAnalyzerReport {
+  languages: Array<{ language: string, count: number }>
+}

--- a/packages/doctor/src/types/File.ts
+++ b/packages/doctor/src/types/File.ts
@@ -1,0 +1,6 @@
+export interface IFileInfo {
+  path: string;
+  source: string;
+  // lines of code
+  LoC: number;
+}

--- a/packages/doctor/src/types/Scanner.ts
+++ b/packages/doctor/src/types/Scanner.ts
@@ -16,13 +16,6 @@ export interface IScanOptions {
   disableRepeatability?: boolean;
 }
 
-export interface IFileInfo {
-  path: string;
-  source: string;
-  // lines of code
-  LoC: number;
-}
-
 // https://www.npmjs.com/package/typhonjs-escomplex
 export interface IMaintainabilityReport {
   classes: any[];


### PR DESCRIPTION
doctor 支持 项目分析，可返回语言分布，示例：
```
{ languages:[
     { language: 'Other', count: 1 },
     { language: 'JSON', count: 3 },
     { language: 'Markdown', count: 1 },
     { language: 'TypeScript', count: 16 },
     { language: 'JavaScript', count: 1 } 
 ] }
```