### PR TITLE
Feat update doctor get files

### DIFF
--- a/packages/doctor/README.md
+++ b/packages/doctor/README.md
@@ -38,15 +38,14 @@ $ iceworks-doctor -s ./
 
 Options
 ```shell
-$ iceworks-doctor -s ./ --ignore types mock --supportExts css json
+$ iceworks-doctor -s ./ --ignore types mock
 ```
 
 ### Options
 
 #### new Doctor(options?);
 
-* ignore?: string[], Ignore directories, example ['mock'] .
-* supportExts?: string[], Support file exts, example ['css'] .
+* ignore?: string[], Ignore directories, example ['mock'] . `.gitignore` will work too.
 
 #### scan('/yourProjectPath', options?);
 
@@ -75,7 +74,7 @@ module.exports = getESLintConfig('react', {
   'no-unused-vars': 'off'
 });
 ```
-`.gitignore` and `.eslintignore` ignore config will merge into ESLint ignore.
+`.eslintignore` ignore config will merge into ESLint ignore.
 
 #### Maintainability
 

--- a/packages/doctor/package.json
+++ b/packages/doctor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@iceworks/doctor",
   "description": "Analyse and running codemods over react/rax projects, troubleshooting and automatically fixing errors",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "keywords": [
     "doctor",
     "analysis",

--- a/packages/doctor/src/Analyzer.ts
+++ b/packages/doctor/src/Analyzer.ts
@@ -28,7 +28,7 @@ export default class Analyzer {
   public analyse(directory: string): IAnalyzerReport {
     const report = { languages: [] };
     const languageCache = {};
-    const files: IFileInfo[] = getFiles(directory, null, this.options.ignore);
+    const files: IFileInfo[] = getFiles(directory, this.options.ignore);
 
     files.forEach((file: IFileInfo) => {
       const language = LANGUAGE_MAP[path.extname(file.path)] || UNKNOWN_LANGUAGE;

--- a/packages/doctor/src/Scanner.ts
+++ b/packages/doctor/src/Scanner.ts
@@ -21,13 +21,7 @@ export default class Scanner {
     const timer = new Timer(options?.timeout);
     const reports = {} as IScannerReports;
 
-    const files: IFileInfo[] = getFiles(directory, this.options.supportExts, this.options.ignore);
-
-    // Process package.json file.
-    const packageFileInfo = getFiles(path.join(directory, 'package.json'), ['json'])[0];
-    if (packageFileInfo) {
-      files.push(packageFileInfo);
-    }
+    const files: IFileInfo[] = getFiles(directory, this.options.ignore);
 
     // Set files info
     reports.filesInfo = {
@@ -46,7 +40,7 @@ export default class Scanner {
         }
         customConfig.parserOptions.project = `${path.join(directory, './')}**/tsconfig.json`;
       }
-      reports.ESLint = getEslintReports(timer, files, ruleKey, customConfig, options?.fix);
+      reports.ESLint = getEslintReports(directory, timer, files, ruleKey, customConfig, options?.fix);
     }
 
     // Calculate maintainability
@@ -56,7 +50,7 @@ export default class Scanner {
 
     // Calculate repeatability
     if (!options || options.disableRepeatability !== true) {
-      reports.repeatability = await getRepeatabilityReports(directory, this.options.supportExts, this.options.ignore, options?.tempFileDir);
+      reports.repeatability = await getRepeatabilityReports(directory, this.options.ignore, options?.tempFileDir);
     }
 
     // Calculate total score

--- a/packages/doctor/src/getFiles.ts
+++ b/packages/doctor/src/getFiles.ts
@@ -8,7 +8,7 @@ import { IFileInfo } from './types/File';
 const MAX_CHECK_LOC = 3000;
 
 // Get ignore config from file
-const IGNORE_CONFIG_FILES = ['.gitignore', '.eslintignore'];
+const IGNORE_CONFIG_FILES = ['.gitignore'];
 
 function getFileInfo(filePath: string): IFileInfo {
   let source = fs.readFileSync(filePath).toString().trim();
@@ -25,7 +25,7 @@ function getFileInfo(filePath: string): IFileInfo {
   };
 }
 
-export default function getFiles(directory: string, supportExts?: string[], ignoreDirs?: string[]): IFileInfo[] {
+export default function getFiles(directory: string, ignoreDirs?: string[]): IFileInfo[] {
   const options: any = {
     nodir: true,
   };
@@ -53,13 +53,8 @@ export default function getFiles(directory: string, supportExts?: string[], igno
       }
     });
 
-    let globPattern = `${directory}/**/*`;
-    if (supportExts) {
-      globPattern = `${directory}/**/*.+(${supportExts.join('|')})`;
-    }
-
     // https://www.npmjs.com/package/glob
-    return glob.sync(globPattern, options)
+    return glob.sync(`${directory}/**/*`, options)
       .map(getFileInfo)
       .filter((file) => {
         // https://www.npmjs.com/package/ignore

--- a/packages/doctor/src/getMaintainabilityReports.ts
+++ b/packages/doctor/src/getMaintainabilityReports.ts
@@ -4,11 +4,15 @@ import Timer from './Timer';
 import { IMaintainabilityReport, IMaintainabilityReports } from './types/Scanner';
 import { IFileInfo } from './types/File';
 
+const SUPPORT_FILE_REG = /(\.js|\.jsx|\.ts|\.tsx)$/;
+
 // https://www.npmjs.com/package/typhonjs-escomplex
 export default function getMaintainabilityReports(timer: Timer, files: IFileInfo[]): IMaintainabilityReports {
   const reports = [];
 
   files.forEach((file) => {
+    if (!SUPPORT_FILE_REG.test(file.path)) return;
+
     try {
       reports.push({
         ...escomplex.analyzeModule(file.source, {

--- a/packages/doctor/src/getRepeatabilityReports.ts
+++ b/packages/doctor/src/getRepeatabilityReports.ts
@@ -5,13 +5,14 @@ import { jscpd } from 'jscpd';
 import Scorer from './Scorer';
 import { IRepeatabilityReports } from './types/Scanner';
 
+const SUPPROT_FILE_EXTS = ['js', 'jsx', 'ts', 'tsx'];
+
 // Write temp file directory
 const tempDir = path.join(__dirname, 'tmp/');
 
 // https://www.npmjs.com/package/jscpd
 export default async function getRepeatabilityReports(
   directory: string,
-  supportExts: string[],
   ignore: string[],
   tempFileDir?: string,
 ): Promise<IRepeatabilityReports> {
@@ -21,7 +22,7 @@ export default async function getRepeatabilityReports(
   try {
     clones = await jscpd([
       '--formats-exts',
-      supportExts.join(','),
+      SUPPROT_FILE_EXTS.join(','),
       directory,
       '--ignore',
       `"${ignore.map((ignoreDir) => `${path.join(directory, '/')}**/${ignoreDir}/**`).join(',')}"`,

--- a/packages/doctor/src/index.ts
+++ b/packages/doctor/src/index.ts
@@ -7,15 +7,10 @@ import { IFileInfo } from './types/File';
 
 // Ignore directories
 const defaultignore = ['build', 'es', 'dist', 'lib', 'mocks', 'coverage', 'node_modules', 'demo', 'examples', 'public', 'test', '__tests__'];
-// Support file exts
-const defaultSupportExts = ['js', 'jsx', 'ts', 'tsx'];
-
 class Doctor {
   public options: any;
 
   public ignore: string[];
-
-  public supportExts: string[];
 
   private scanner: any;
 
@@ -25,12 +20,8 @@ class Doctor {
     this.options = options || {};
 
     this.ignore = defaultignore.concat(this.options.ignore || []);
-    this.supportExts = defaultSupportExts.concat(this.options.supportExts || []);
 
-    this.scanner = new Scanner({
-      ignore: this.ignore,
-      supportExts: this.supportExts,
-    });
+    this.scanner = new Scanner({ ignore: this.ignore });
 
     this.analyzer = new Analyzer({ ignore: this.ignore });
   }
@@ -44,7 +35,7 @@ class Doctor {
   }
 
   getFiles(directory: string): IFileInfo[] {
-    return getFiles(directory, this.supportExts, this.ignore);
+    return getFiles(directory, this.ignore);
   }
 }
 

--- a/packages/doctor/src/types/Doctor.ts
+++ b/packages/doctor/src/types/Doctor.ts
@@ -1,4 +1,3 @@
 export interface IDoctorOptions {
   ignore?: string[];
-  supportExts?: string[];
 }

--- a/packages/doctor/src/types/Scanner.ts
+++ b/packages/doctor/src/types/Scanner.ts
@@ -2,7 +2,6 @@ import { IClone } from '@jscpd/core';
 
 export interface IScannerOptions {
   ignore: string[];
-  supportExts: string[];
 }
 
 export interface IScanOptions {


### PR DESCRIPTION
Doctor 支持项目 languages 分析，可读取的文件不止有 js，jsx，ts，tsx。
更新：
* getFiles 方法，返回所有文件，在不同分析函数中，区分各自支持的文件类型。
* getFiles 方法支持 .gitignore 配置
* 去除 supportExts 参数，由各个分析器决定支持的文件