### PR TITLE
fix: page cannot be created when block name is duplicate

### DIFF
--- a/extensions/iceworks-material-helper/CHANGELOG.md
+++ b/extensions/iceworks-material-helper/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.5.3
 
 - fix: rax-app language type is always ts
+- fix: page cannot be created when block name is duplicate
 
 ## 0.5.2
 

--- a/extensions/iceworks-material-helper/web/src/pages/PageGenerator/index.tsx
+++ b/extensions/iceworks-material-helper/web/src/pages/PageGenerator/index.tsx
@@ -65,7 +65,20 @@ const Home = () => {
     }
   }
 
+  function generateBlockName(defineName: string): Promise<string> {
+    function generateName(setName, count = 0) {
+      const newName = !count ? setName : `${setName}${count}`;
+      const isConflict = selectedBlocks.some(({ name }) => name === newName);
+      if (isConflict) {
+        return generateName(setName, count + 1);
+      }
+      return newName;
+    }
+    return generateName(defineName);
+  }
+
   function onAdd(block) {
+    block.name = generateBlockName(block.name);
     setSelectedBlocks([...selectedBlocks, block]);
   }
 


### PR DESCRIPTION
https://github.com/ice-lab/iceworks/issues/734