### PR TITLE
refactor: save user info to iceworks configuration

### DIFF
--- a/extensions/iceworks-doctor/package.json
+++ b/extensions/iceworks-doctor/package.json
@@ -69,7 +69,7 @@
       "type": "object",
       "title": "Iceworks Doctor",
       "properties": {
-        "Iceworks.Doctor.enableCheckSecurityPracticesOnSave": {
+        "iceworks.enableCheckSecurityPracticesOnSave": {
           "scope": "window",
           "type": "boolean",
           "default": true,

--- a/extensions/iceworks-doctor/src/extension.ts
+++ b/extensions/iceworks-doctor/src/extension.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import * as fse from 'fs-extra';
 import * as path from 'path';
 import { connectService, getHtmlForWebview } from '@iceworks/vscode-webview/lib/vscode';
-import { registerCommand, initExtension } from '@iceworks/common-service';
+import { registerCommand, initExtension, getDataFromSettingJson } from '@iceworks/common-service';
 import getRecorder from './getRecorder';
 import getScanReport from './getScanReport';
 import setDiagnostics from './setDiagnostics';
@@ -27,10 +27,8 @@ export function activate(context: vscode.ExtensionContext) {
   vscode.workspace.onDidSaveTextDocument(
     (editor) => {
       if (editor && editor.fileName) {
-        const configuration = workspace.getConfiguration();
-
         if (
-          configuration.get('Iceworks.Doctor.enableCheckSecurityPracticesOnSave') &&
+          getDataFromSettingJson('enableCheckSecurityPracticesOnSave') &&
           // Only check js file
           /(jsx|js|tsx|ts)$/.test(editor.fileName)
         ) {

--- a/extensions/iceworks-material-helper/CHANGELOG.md
+++ b/extensions/iceworks-material-helper/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.5.4
+
+- refactor: internal optimization
+
 ## 0.5.3
 
 - fix: rax-app language type is always ts

--- a/extensions/iceworks-material-helper/package.json
+++ b/extensions/iceworks-material-helper/package.json
@@ -3,7 +3,7 @@
   "displayName": "Component Helper",
   "description": "Easily use Component in React/Vue/Rax.",
   "publisher": "iceworks-team",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "main": "./build/extension.js",
   "engines": {
     "vscode": "^1.41.0"
@@ -82,7 +82,7 @@
     "configuration": {
       "title": "Iceworks Material Helper",
       "properties": {
-        "iceworks.materialHelper.openDocLinkInsideVSCode": {
+        "iceworks.openDocLinkInsideVSCode": {
           "type": "boolean",
           "default": false,
           "description": "%iceworksMaterialHelper.configuration.openInBrowserDescription%",

--- a/extensions/iceworks-material-helper/src/componentDocSupport/openInBowser.ts
+++ b/extensions/iceworks-material-helper/src/componentDocSupport/openInBowser.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { getDataFromSettingJson } from '@iceworks/common-service';
 import recorder from '../utils/recorder';
 
 function openInExternalBrowser(url) {
@@ -10,7 +11,7 @@ function openInInternalBrowser(url: string) {
 }
 
 function openDocLinkInsideVSCode() {
-  return vscode.workspace.getConfiguration('iceworks.materialHelper').get('openDocLinkInsideVSCode') && vscode.extensions.getExtension('auchenberg.vscode-browser-preview');
+  return getDataFromSettingJson('openDocLinkInsideVSCode') && vscode.extensions.getExtension('auchenberg.vscode-browser-preview');
 }
 
 export default function openInBrowser(url) {

--- a/extensions/iceworks-project-creator/package.json
+++ b/extensions/iceworks-project-creator/package.json
@@ -42,29 +42,6 @@
           "type": "string",
           "default": "",
           "description": "Iceworks workspace"
-        },
-        "iceworks.user": {
-          "type": "object",
-          "default": {
-            "empId": "",
-            "account": "",
-            "gitlabToken": ""
-          },
-          "properties": {
-            "empId": {
-              "type": "string",
-              "description": "工号"
-            },
-            "account": {
-              "type": "string",
-              "description": "域账号"
-            },
-            "gitlabToken": {
-              "type": "string",
-              "description": "gitlab 私人 token"
-            }
-          },
-          "description": "Iceworks user information"
         }
       }
     }

--- a/extensions/iceworks-project-creator/web/src/pages/CreateProject/index.tsx
+++ b/extensions/iceworks-project-creator/web/src/pages/CreateProject/index.tsx
@@ -184,7 +184,7 @@ const CreateProject: React.FC = () => {
         ...curProjectField,
         clientToken: CLIENT_TOKEN,
       });
-      await callService('common', 'saveDataToSettingJson', 'user', { empId, account, gitlabToken });
+      await callService('common', 'saveUserInfo', { empId, account, gitlabToken });
       await callService('common', 'saveDataToSettingJson', 'workspace', projectPath);
       await callService('project', 'openLocalProjectFolder', projectDir);
     } catch (e) {

--- a/packages/common-service/package.json
+++ b/packages/common-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iceworks/common-service",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "description": "Iceworks common service for VSCode extension.",
   "files": [
     "lib"
@@ -14,6 +14,7 @@
     "@iceworks/constant": "^0.1.0",
     "@iceworks/i18n": "^0.1.0",
     "@iceworks/material-utils": "^0.1.5",
+    "@iceworks/configure": "^0.1.0",
     "@iceworks/recorder": "^0.1.0",
     "axios": "^0.19.2",
     "co": "4.6.0",

--- a/packages/constant/README.md
+++ b/packages/constant/README.md
@@ -1,0 +1,1 @@
+## Constant

--- a/packages/constant/src/index.ts
+++ b/packages/constant/src/index.ts
@@ -1,5 +1,6 @@
 import { Base64 } from 'js-base64';
 
+// Some internal URLs are not suitable for direct disclosure
 export const ALI_NPM_REGISTRY = Base64.decode('aHR0cHM6Ly9yZWdpc3RyeS5ucG0uYWxpYmFiYS1pbmMuY29t');
 export const ALI_GITACCOUNT_URL = Base64.decode('aHR0cDovL2dpdGxhYi5hbGliYWJhLWluYy5jb20vcHJvZmlsZS9hY2NvdW50');
 export const ALI_GITACCOUNT_SHORTURL = Base64.decode('Z2l0bGFiLmFsaWJhYmEtaW5jLmNvbS9wcm9maWxlL2FjY291bnQ=');


### PR DESCRIPTION
之前用户信息一直存放在编辑器的配置里，这样的话用户是会在设置面板感知并且更新该信息，这不符合期望。

此次更新将用户信息存储到 iceworks 的本地设置文件。