### PR TITLE
feat: set includes for o2

### DIFF
--- a/scripts/o2/template/package.json
+++ b/scripts/o2/template/package.json
@@ -24,6 +24,10 @@
   "kaitianContributes": {
     "nodeMain": "./out/node/index.js",
     "browserMain": "./out/browser/index.js",
+    "includes": [
+      "iceworks-team.iceworks-time-master",
+      "tao.def-basic-kit"
+    ],
     "toolbar": {
       "actions": [
         {


### PR DESCRIPTION
includes 字段可以在 O2 内禁止某些插件的启动，这在当套件已包含了某些插件，用户又安装了这些插件时，可以避免重复的激活。