### PR TITLE
更新 preview 页面

### DIFF
--- a/extensions/iceworks-app/CHANGELOG.md
+++ b/extensions/iceworks-app/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Change Log
-
 ## 0.8.2
 
 - refactor: internal optimization
+- fix: preview frame mobile mode switch
+- feat: preview frame add page select
 
 ## 0.8.1
 

--- a/extensions/iceworks-app/CHANGELOG.md
+++ b/extensions/iceworks-app/CHANGELOG.md
@@ -4,6 +4,7 @@
 - refactor: internal optimization
 - fix: preview frame mobile mode switch
 - feat: preview frame add page select
+- feat: auto open preview frame when `npm run start` in O2
 
 ## 0.8.1
 

--- a/extensions/iceworks-app/package.json
+++ b/extensions/iceworks-app/package.json
@@ -339,6 +339,7 @@
     "@iceworks/project-service": "^0.2.0",
     "@iceworks/recorder": "^0.1.6",
     "@iceworks/vscode-webview": "^0.1.2",
+    "chokidar": "^3.5.1",
     "comment-json": "^3.0.2",
     "ejs": "^3.1.3",
     "fs-extra": "^9.0.0",

--- a/extensions/iceworks-app/src/extension.ts
+++ b/extensions/iceworks-app/src/extension.ts
@@ -7,13 +7,14 @@ import {
   projectPath,
 } from '@iceworks/project-service';
 import { Recorder } from '@iceworks/recorder';
-import { initExtension, registerCommand, getFolderExistsTime, getDataFromSettingJson } from '@iceworks/common-service';
+import { checkIsO2, initExtension, registerCommand, getFolderExistsTime, getDataFromSettingJson } from '@iceworks/common-service';
 import { createActionsTreeView } from './views/actionsView';
 import { createNodeDependenciesTreeView } from './views/nodeDependenciesView';
 import { createQuickEntriesTreeView } from './views/quickEntriesView';
 import services from './services';
 import { showExtensionsQuickPickCommandId, projectExistsTime } from './constants';
 import showAllQuickPick from './quickPicks/showAllQuickPick';
+import autoOpenPreview from './utils/preview/autoOpenPreview';
 import createScriptsCommands from './utils/createScriptsCommands';
 import createExtensionsStatusBar from './statusBar/createExtensionsStatusBar';
 import i18n from './i18n';
@@ -24,6 +25,11 @@ const recorder = new Recorder(name, version);
 
 export async function activate(context: vscode.ExtensionContext) {
   const { subscriptions, extensionPath } = context;
+
+  if (checkIsO2()) {
+    // only auto open preview in O2
+    autoOpenPreview(context, recorder);
+  }
 
   console.log('Congratulations, your extension "iceworks-app" is now active!');
   recorder.recordActivate();

--- a/extensions/iceworks-app/src/utils/createScriptsCommands.ts
+++ b/extensions/iceworks-app/src/utils/createScriptsCommands.ts
@@ -1,82 +1,22 @@
-import * as fs from 'fs-extra';
-import * as path from 'path';
 import * as vscode from 'vscode';
 import { createNpmCommand, checkPathExists, registerCommand } from '@iceworks/common-service';
-import { checkIsPegasusProject, dependencyDir, getProjectFramework, projectPath } from '@iceworks/project-service';
-import { connectService, getHtmlForWebview } from '@iceworks/vscode-webview/lib/vscode';
-import { DEFAULT_START_URL, IDevServerStartInfo, getDevServerStartInfo } from './getDevServerStartInfo';
-import services from '../services';
+import { dependencyDir, projectPath } from '@iceworks/project-service';
+import openPreviewWebview from './preview/openPreviewWebview';
 import showDefPublishEnvQuickPick from '../quickPicks/showDefPublishEnvQuickPick';
 import runScript from '../terminal/runScript';
 
-let previewWebviewPanel: vscode.WebviewPanel | undefined;
-
 export default async function createScriptsCommands(context: vscode.ExtensionContext, recorder) {
-  const { window } = vscode;
-  const { extensionPath } = context;
-
-  function openPreview(startInfo?: IDevServerStartInfo) {
-    if (!startInfo) {
-      return;
-    }
-
-    if (previewWebviewPanel) {
-      previewWebviewPanel.reveal();
-    }
-
-    previewWebviewPanel = window.createWebviewPanel('iceworks', 'Preview', vscode.ViewColumn.Two, {
-      enableScripts: true,
-      retainContextWhenHidden: true,
-    });
-
-    const extraHtml = `<script>window.__PREVIEW__DATA__ = ${JSON.stringify(startInfo || { startUrl: DEFAULT_START_URL })};</script>`;
-
-    previewWebviewPanel.webview.html = getHtmlForWebview(extensionPath, 'preview', false, undefined, extraHtml);
-    previewWebviewPanel.onDidDispose(
-      () => {
-        previewWebviewPanel = undefined;
-      },
-      null,
-      context.subscriptions,
-    );
-    connectService(previewWebviewPanel, context, { services, recorder });
-  }
-
   const EDITOR_MENU_RUN_DEBUG = 'iceworksApp.scripts.runDebug';
   registerCommand(EDITOR_MENU_RUN_DEBUG, async () => {
-    let shouldInstall = false;
-    const isPegasusProject = await checkIsPegasusProject();
-
     // Check dependences
     let scripts = createNpmCommand('run', 'start');
     if (!(await checkPathExists(projectPath, dependencyDir))) {
-      shouldInstall = true;
       scripts = `${createNpmCommand('install')} && ${scripts}`;
     }
-
     // npm run start.
     // Debug in VS Code move to iceworks docs.
     runScript('Run Debug', projectPath, scripts);
-
-    if (await getProjectFramework() === 'rax-app') {
-      const devServerStartInfo: IDevServerStartInfo | undefined = await getDevServerStartInfo(projectPath, shouldInstall ? 4 * 60000 : 2 * 60000);
-      openPreview(devServerStartInfo);
-    } else if (isPegasusProject) {
-      // Set pegasus service url
-      try {
-        const abcConfigFile = path.join(projectPath, 'abc.json');
-        if (fs.existsSync(abcConfigFile)) {
-          const abcConfig = fs.readJSONSync(abcConfigFile);
-          if (abcConfig.type === 'pegasus' && abcConfig.group && abcConfig.name) {
-            setTimeout(() => {
-              openPreview({ startUrl: `${DEFAULT_START_URL}${abcConfig.group}/${abcConfig.name}` });
-            }, 10000);
-          }
-        }
-      } catch (e) {
-        // ignore
-      }
-    }
+    openPreviewWebview(context, recorder);
   });
 
   const EDITOR_MENU_RUN_BUILD = 'iceworksApp.scripts.runBuild';

--- a/extensions/iceworks-app/src/utils/preview/autoOpenPreview.ts
+++ b/extensions/iceworks-app/src/utils/preview/autoOpenPreview.ts
@@ -1,0 +1,45 @@
+// listen dev.json file change auto open prefive frame. like only run `npm run start`
+
+import * as fs from 'fs-extra';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import * as chokidar from 'chokidar';
+import { projectPath } from '@iceworks/project-service';
+import openPreviewWebview from './openPreviewWebview';
+
+// node_modules/.tmp/@builder/dev.json
+const DEV_INFO_BASE_DIR = path.join(projectPath, 'node_modules');
+const DEV_INFO_FILE_DIR = path.join(DEV_INFO_BASE_DIR, '.tmp/@builder');
+const DEV_INFO_FILE = path.join(DEV_INFO_FILE_DIR, 'dev.json');
+
+export default function autoOpenPreview(context: vscode.ExtensionContext, recorder) {
+  // chokidar can’t watch file if file's parent dir not exists
+  const watcher = chokidar.watch('file, dir', { disableGlobbing: true });
+
+  if (!fs.existsSync(DEV_INFO_BASE_DIR)) {
+    // wait for base dir created
+    watcher.add('.');
+  } else {
+    watcher.add(DEV_INFO_FILE);
+  }
+
+  // user may not install node modules and not setup temp dir
+  watcher.on('addDir', (newPath) => {
+    if (newPath === DEV_INFO_BASE_DIR) {
+      watcher.unwatch('.');
+      if (!fs.existsSync(DEV_INFO_FILE_DIR)) {
+        fs.mkdirsSync(DEV_INFO_FILE_DIR);
+        watcher.add(DEV_INFO_FILE);
+      }
+    }
+  });
+
+  // watch dev.json file create and change
+  watcher
+    .on('add', () => {
+      openPreviewWebview(context, recorder);
+    })
+    .on('change', () => {
+      openPreviewWebview(context, recorder);
+    });
+}

--- a/extensions/iceworks-app/src/utils/preview/autoOpenPreview.ts
+++ b/extensions/iceworks-app/src/utils/preview/autoOpenPreview.ts
@@ -18,7 +18,7 @@ export default function autoOpenPreview(context: vscode.ExtensionContext, record
 
   if (!fs.existsSync(DEV_INFO_BASE_DIR)) {
     // wait for base dir created
-    watcher.add('.');
+    watcher.add(projectPath);
   } else {
     watcher.add(DEV_INFO_FILE);
   }
@@ -26,7 +26,7 @@ export default function autoOpenPreview(context: vscode.ExtensionContext, record
   // user may not install node modules and not setup temp dir
   watcher.on('addDir', (newPath) => {
     if (newPath === DEV_INFO_BASE_DIR) {
-      watcher.unwatch('.');
+      watcher.unwatch(projectPath);
       if (!fs.existsSync(DEV_INFO_FILE_DIR)) {
         fs.mkdirsSync(DEV_INFO_FILE_DIR);
         watcher.add(DEV_INFO_FILE);

--- a/extensions/iceworks-app/src/utils/preview/autoOpenPreview.ts
+++ b/extensions/iceworks-app/src/utils/preview/autoOpenPreview.ts
@@ -1,4 +1,6 @@
-// listen dev.json file change auto open prefive frame. like only run `npm run start`
+/**
+ * listen dev.json file change auto open prefive frame. like only run `npm run start`
+ */
 
 import * as fs from 'fs-extra';
 import * as path from 'path';

--- a/extensions/iceworks-app/src/utils/preview/openPreviewWebview.ts
+++ b/extensions/iceworks-app/src/utils/preview/openPreviewWebview.ts
@@ -1,0 +1,63 @@
+import * as fs from 'fs-extra';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { checkIsPegasusProject, getProjectFramework, projectPath } from '@iceworks/project-service';
+import { connectService, getHtmlForWebview } from '@iceworks/vscode-webview/lib/vscode';
+import { DEFAULT_START_URL, IDevServerStartInfo, getDevServerStartInfo } from '../getDevServerStartInfo';
+import services from '../../services';
+
+let previewWebviewPanel: vscode.WebviewPanel | undefined;
+
+export default async function openPreview(context: vscode.ExtensionContext, recorder) {
+  const { window } = vscode;
+  const { extensionPath } = context;
+
+  let startInfo: IDevServerStartInfo | undefined;
+
+  const isPegasusProject = await checkIsPegasusProject();
+
+  if (await getProjectFramework() === 'rax-app') {
+    startInfo = await getDevServerStartInfo(projectPath, 4 * 60000);
+  } else if (isPegasusProject) {
+    // Set pegasus service url
+    try {
+      const abcConfigFile = path.join(projectPath, 'abc.json');
+      if (fs.existsSync(abcConfigFile)) {
+        const abcConfig = fs.readJSONSync(abcConfigFile);
+        if (abcConfig.type === 'pegasus' && abcConfig.group && abcConfig.name) {
+          setTimeout(() => {
+            startInfo = { startUrl: `${DEFAULT_START_URL}${abcConfig.group}/${abcConfig.name}` };
+          }, 10000);
+        }
+      }
+    } catch (e) {
+      // ignore
+    }
+  }
+
+  if (!startInfo) {
+    return;
+  }
+
+  if (previewWebviewPanel) {
+    previewWebviewPanel.reveal();
+    return;
+  }
+
+  previewWebviewPanel = window.createWebviewPanel('iceworks', 'Preview', vscode.ViewColumn.Two, {
+    enableScripts: true,
+    retainContextWhenHidden: true,
+  });
+
+  const extraHtml = `<script>window.__PREVIEW__DATA__ = ${JSON.stringify(startInfo || { startUrl: DEFAULT_START_URL })};</script>`;
+
+  previewWebviewPanel.webview.html = getHtmlForWebview(extensionPath, 'preview', false, undefined, extraHtml);
+  previewWebviewPanel.onDidDispose(
+    () => {
+      previewWebviewPanel = undefined;
+    },
+    null,
+    context.subscriptions,
+  );
+  connectService(previewWebviewPanel, context, { services, recorder });
+}

--- a/extensions/iceworks-app/web/src/pages/Preview/components/Header/PageSelect.tsx
+++ b/extensions/iceworks-app/web/src/pages/Preview/components/Header/PageSelect.tsx
@@ -1,0 +1,49 @@
+import React, { useState, useEffect } from 'react';
+import { Select } from '@alifd/next';
+
+const { Option } = Select;
+
+interface IProps {
+  url: string;
+  setUrl: any;
+}
+
+export default function (props: IProps) {
+  let pageSelect = null;
+
+  const { startQRCodeInfo } = window.__PREVIEW__DATA__;
+
+  if (startQRCodeInfo && startQRCodeInfo.web && startQRCodeInfo.web.length > 1) {
+    const { url, setUrl } = props;
+    const [pageUrl, setPageUrl] = useState('');
+
+    useEffect(() => {
+      if (startQRCodeInfo.web.find(u => url.indexOf(u) === 0)) {
+        setPageUrl(url);
+      } else {
+        setPageUrl('');
+      }
+    }, [url]);
+
+    const onChange = (value) => {
+      setUrl(value);
+      setPageUrl(value);
+    };
+
+    pageSelect = (
+      <Select
+        value={pageUrl}
+        onChange={onChange}
+        size="medium"
+        hasBorder={false}
+        label="page:"
+        valueRender={(item: any) => <p style={{ color: '#01C1B2' }}>{item.label}</p>}
+      >
+        {startQRCodeInfo.web.map((webUrl: string) => {
+          return <Option key={webUrl} value={webUrl}>{webUrl.substring(webUrl.lastIndexOf('/') + 1).replace('.html', '')}</Option>;
+        })}
+      </Select>
+    );
+  }
+  return pageSelect;
+}

--- a/extensions/iceworks-app/web/src/pages/Preview/components/Header/PageSelect.tsx
+++ b/extensions/iceworks-app/web/src/pages/Preview/components/Header/PageSelect.tsx
@@ -1,50 +1,40 @@
-import React, { useState, useEffect } from 'react';
+import React, { useContext, useState, useEffect } from 'react';
 import { Select } from '@alifd/next';
+import { Context } from '../../context';
 
 const { Option } = Select;
 
 interface IProps {
-  url: string;
-  setUrl: any;
+  onChange: any;
 }
 
 export default function (props: IProps) {
-  let pageSelect = null;
-
   const { startQRCodeInfo } = window.__PREVIEW__DATA__;
 
-  if (startQRCodeInfo && startQRCodeInfo.web && startQRCodeInfo.web.length > 1) {
-    const { url, setUrl } = props;
-    const [pageUrl, setPageUrl] = useState('');
+  const { url } = useContext(Context);
+  const [pageUrl, setPageUrl] = useState('');
 
-    useEffect(() => {
-      const newUrl = startQRCodeInfo.web.find(u => url.indexOf(u) === 0);
-      if (newUrl) {
-        setPageUrl(newUrl);
-      } else {
-        setPageUrl('');
-      }
-    }, [url]);
+  useEffect(() => {
+    const newUrl = startQRCodeInfo?.web?.find(u => url.indexOf(u) === 0);
+    if (newUrl) {
+      setPageUrl(newUrl);
+    } else {
+      setPageUrl('');
+    }
+  }, [url]);
 
-    const onChange = (value) => {
-      setUrl(value);
-      setPageUrl(value);
-    };
-
-    pageSelect = (
-      <Select
-        value={pageUrl}
-        onChange={onChange}
-        size="medium"
-        hasBorder={false}
-        label="page:"
-        valueRender={(item: any) => <p style={{ color: '#01C1B2' }}>{item.label}</p>}
-      >
-        {startQRCodeInfo.web.map((webUrl: string) => {
-          return <Option key={webUrl} value={webUrl}>{webUrl.substring(webUrl.lastIndexOf('/') + 1).replace('.html', '')}</Option>;
-        })}
-      </Select>
-    );
-  }
-  return pageSelect;
+  return startQRCodeInfo?.web?.length > 1 ? (
+    <Select
+      value={pageUrl}
+      onChange={(val) => { props.onChange(val); }}
+      size="medium"
+      hasBorder={false}
+      label="page:"
+      valueRender={(item: any) => <p style={{ color: '#01C1B2' }}>{item.label}</p>}
+    >
+      {startQRCodeInfo.web.map((webUrl: string) => {
+        return <Option key={webUrl} value={webUrl}>{webUrl.substring(webUrl.lastIndexOf('/')).replace(/\/([^.]+)(\.html)?/, '$1')}</Option>;
+      })}
+    </Select>
+  ) : null;
 }

--- a/extensions/iceworks-app/web/src/pages/Preview/components/Header/PageSelect.tsx
+++ b/extensions/iceworks-app/web/src/pages/Preview/components/Header/PageSelect.tsx
@@ -18,8 +18,9 @@ export default function (props: IProps) {
     const [pageUrl, setPageUrl] = useState('');
 
     useEffect(() => {
-      if (startQRCodeInfo.web.find(u => url.indexOf(u) === 0)) {
-        setPageUrl(url);
+      const newUrl = startQRCodeInfo.web.find(u => url.indexOf(u) === 0);
+      if (newUrl) {
+        setPageUrl(newUrl);
       } else {
         setPageUrl('');
       }

--- a/extensions/iceworks-app/web/src/pages/Preview/components/Header/index.tsx
+++ b/extensions/iceworks-app/web/src/pages/Preview/components/Header/index.tsx
@@ -1,10 +1,12 @@
-import React, { useEffect, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { Balloon, Icon, Input } from '@alifd/next';
 import classNames from 'classnames';
 import PageSelect from './PageSelect';
 import QRCodeWrap from '../QRCodeWrap/';
 import { UrlHistory } from './url-history';
+import { Context } from '../../context';
 import { BLANK_URL } from '../../config';
+
 import styles from './index.module.scss';
 import './icon.css';
 
@@ -12,17 +14,13 @@ import './icon.css';
 // H5: https://www.tmall.com/?wh_ttid=@phone
 const PHONE_NODE_QUERY = 'wh_ttid=@phone';
 
-interface IProps {
-  url: string;
-  setUrl: any;
-  refresh: any;
-}
 
 const history = new UrlHistory();
 
-export default function (props: IProps) {
-  const { url, setUrl, refresh } = props;
-  const [currentUrl, setCurrentUrl] = useState(url);
+export default function () {
+  const { url, setUrl, previewerRef } = useContext(Context);
+
+  const [inputUrl, setInputUrl] = useState(url);
 
   useEffect(() => {
     history.push(url);
@@ -34,7 +32,7 @@ export default function (props: IProps) {
       target = `https://${newUrl}`;
     }
     setUrl(target);
-    setCurrentUrl(target);
+    setInputUrl(target);
     if (!fromHistory) {
       history.push(target);
     }
@@ -85,20 +83,15 @@ export default function (props: IProps) {
           <QRCodeWrap url={url} />
         </div>
       </Balloon>
-      <div className={styles.icon} onClick={() => { refresh && refresh(); }}>
+      <div className={styles.icon} onClick={() => { previewerRef?.current.refresh(); }}>
         <Icon type="refresh" size="xs" />
       </div>
       <Input
-        addonBefore={
-          <PageSelect
-            url={url}
-            setUrl={(newUrl: string) => { setUrl(newUrl); setCurrentUrl(newUrl); }}
-          />
-        }
-        value={currentUrl}
+        addonBefore={<PageSelect onChange={setNewUrl} />}
+        value={inputUrl}
         size="medium"
         hasBorder={false}
-        onChange={(value) => { setCurrentUrl(value); }}
+        onChange={(value) => { setInputUrl(value); }}
         onPressEnter={handleEnter}
       />
     </div>

--- a/extensions/iceworks-app/web/src/pages/Preview/components/Header/index.tsx
+++ b/extensions/iceworks-app/web/src/pages/Preview/components/Header/index.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Balloon, Icon, Input } from '@alifd/next';
 import classNames from 'classnames';
+import PageSelect from './PageSelect';
 import QRCodeWrap from '../QRCodeWrap/';
 import { UrlHistory } from './url-history';
 import { BLANK_URL } from '../../config';
@@ -46,7 +47,7 @@ export default function (props: IProps) {
   const handlePhoneIconClick = () => {
     let newUrl = '';
     if (new RegExp(PHONE_NODE_QUERY).test(url)) {
-      newUrl = url.replace(PHONE_NODE_QUERY, '');
+      newUrl = url.replace(PHONE_NODE_QUERY, '').replace(/[?|&]$/, '');
     } else {
       newUrl = `${url}${url.indexOf('?') === -1 ? '?' : '&'}${PHONE_NODE_QUERY}`;
     }
@@ -87,7 +88,19 @@ export default function (props: IProps) {
       <div className={styles.icon} onClick={() => { refresh && refresh(); }}>
         <Icon type="refresh" size="xs" />
       </div>
-      <Input value={currentUrl} size="medium" hasBorder={false} onChange={(value) => { setCurrentUrl(value); }} onPressEnter={handleEnter} />
+      <Input
+        addonBefore={
+          <PageSelect
+            url={url}
+            setUrl={(newUrl: string) => { setUrl(newUrl); setCurrentUrl(newUrl); }}
+          />
+        }
+        value={currentUrl}
+        size="medium"
+        hasBorder={false}
+        onChange={(value) => { setCurrentUrl(value); }}
+        onPressEnter={handleEnter}
+      />
     </div>
   );
 }

--- a/extensions/iceworks-app/web/src/pages/Preview/components/Previewer/index.tsx
+++ b/extensions/iceworks-app/web/src/pages/Preview/components/Previewer/index.tsx
@@ -1,16 +1,13 @@
-import React, { forwardRef, useEffect, useImperativeHandle, useRef } from 'react';
+import React, { forwardRef, useContext, useEffect, useImperativeHandle, useRef } from 'react';
 import LoadingPercent from '../LoadingPercent';
+import { Context } from '../../context';
 import { BLANK_URL } from '../../config';
 import styles from './index.module.scss';
 
-interface IProps {
-  url: string
-}
-
 const REFRESH_TIMEOUT = 200;
 
-function Previewer(props: IProps, ref) {
-  const { url } = props;
+function Previewer(props, ref) {
+  const { url } = useContext(Context);
 
   const frameRef = useRef(null);
   const loadingPercentRef = useRef(null);

--- a/extensions/iceworks-app/web/src/pages/Preview/context.ts
+++ b/extensions/iceworks-app/web/src/pages/Preview/context.ts
@@ -1,0 +1,3 @@
+import React from 'react';
+
+export const Context = React.createContext(null);

--- a/extensions/iceworks-app/web/src/pages/Preview/index.tsx
+++ b/extensions/iceworks-app/web/src/pages/Preview/index.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef } from 'react';
 import Header from './components/Header';
 import Previewer from './components/Previewer';
+import { Context } from './context';
 import { BLANK_URL } from './config';
 import styles from './index.module.scss';
 
@@ -24,9 +25,11 @@ export default function () {
   const previewerRef = useRef(null);
 
   return (
-    <div className={styles.container} >
-      <Header url={url} setUrl={setUrl} refresh={() => { previewerRef.current.refresh(); }} />
-      <Previewer ref={previewerRef} url={url} />
-    </div>
+    <Context.Provider value={{ url, setUrl, previewerRef }}>
+      <div className={styles.container} >
+        <Header />
+        <Previewer ref={previewerRef} />
+      </div>
+    </Context.Provider>
   );
 }

--- a/package.json
+++ b/package.json
@@ -104,5 +104,8 @@
     "**/*.{js,jsx,ts,tsx}": "xima exec eslint",
     "**/*.{css,scss,less}": "xima exec stylelint",
     "**/*.md": "npm run docs:check"
+  },
+  "dependencies": {
+    "chokidar": "^3.5.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -104,8 +104,5 @@
     "**/*.{js,jsx,ts,tsx}": "xima exec eslint",
     "**/*.{css,scss,less}": "xima exec stylelint",
     "**/*.md": "npm run docs:check"
-  },
-  "dependencies": {
-    "chokidar": "^3.5.1"
   }
 }


### PR DESCRIPTION
* 修复 手机模式切换 遗留的 ？和 & 符号
* 新增页面选择功能，可快速跳转可跳页面
* 新增自动唤起预览窗口功能，用户在 O2 环境执行 npm run start 即可自动唤起。（VS Code 环境暂时避免干扰用户）

实现原理：监听 dev.json 文件变化，执行相应逻辑

![image](https://user-images.githubusercontent.com/9896768/108981440-b14b3e80-76c7-11eb-9ce4-9f4d96e0791d.png)
![(null) 2021-02-25 11_00_31](https://user-images.githubusercontent.com/9896768/109096563-bc9a7a80-7758-11eb-93ab-1bafc7e94976.gif)
