### PR TITLE
Chore: remove ignore package in iceworks-app

### DIFF
--- a/extensions/iceworks-app/.vscodeignore
+++ b/extensions/iceworks-app/.vscodeignore
@@ -8,5 +8,3 @@ src/**
 node_modules
 webpack.config.js
 web/**
-!node_modules/prettier
-!node_modules/@iceworks/code-generator

--- a/extensions/iceworks-app/CHANGELOG.md
+++ b/extensions/iceworks-app/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 0.8.2
 
 - refactor: internal optimization
-- chore: remove package ignore
+- chore: not ignore packages (`prettier` and `@iceworks/code-generator`) when packaging extension
 
 ## 0.8.1
 

--- a/extensions/iceworks-app/CHANGELOG.md
+++ b/extensions/iceworks-app/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.8.2
 
 - refactor: internal optimization
+- chore: remove package ignore
 
 ## 0.8.1
 


### PR DESCRIPTION
由于使用的 @iceworks/material-engine 支持按需加载，没有引用到 `prettier` 和 `@iceworks/code-generator` 两个包，因此不需要对这两个 npm 包进行 external