### PR TITLE
fix: save scaffoldValue

### DIFF
--- a/extensions/iceworks-project-creator/CHANGELOG.md
+++ b/extensions/iceworks-project-creator/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 0.4.11 
+
+- fix: save user config data in template preview.
 ## 0.4.10
 
 - refactor: internal optimization

--- a/extensions/iceworks-project-creator/package.json
+++ b/extensions/iceworks-project-creator/package.json
@@ -3,7 +3,7 @@
   "displayName": "Application Creator",
   "description": "Quick create a Universal Application(React/Rax/Vue, etc).",
   "publisher": "iceworks-team",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "engines": {
     "vscode": "^1.41.0"
   },

--- a/extensions/iceworks-project-creator/web/src/pages/CustomScaffold/components/ScaffoldForm/index.tsx
+++ b/extensions/iceworks-project-creator/web/src/pages/CustomScaffold/components/ScaffoldForm/index.tsx
@@ -21,6 +21,9 @@ const Scaffoldform = ({ children, onChange, scaffoldValue }) => {
     iframeRef.current.contentWindow.document.open();
     iframeRef.current.contentWindow.document.write(Base64.decode(window.iframeContent));
     iframeRef.current.contentWindow.document.close();
+    iframeRef.current.onload = () => {
+      sendMessage(JSON.stringify(scaffoldValue));
+    };
   };
 
   useEffect(() => {


### PR DESCRIPTION
当用户在使用模板创建应用后，选择自定义模板创建应用。
进行配置后，点击下一步。
如果此时用户返回，则用户配置的模板数据保存，但是预览不会更新为数据的样式。

修改为 ====>
当用户返回，预览更新为用户配置的模板数据样式。