### PR TITLE
fix: upgrade next-js-codemod

### DIFF
--- a/extensions/iceworks-codemod/jscodeshift/package.json
+++ b/extensions/iceworks-codemod/jscodeshift/package.json
@@ -4,7 +4,7 @@
     "@babel/preset-env": "^7.13.15",
     "acorn": "^8.1.1",
     "icejs-codemod": "0.1.2",
-    "next-js-codemod": "1.0.1",
+    "next-js-codemod": "1.0.2",
     "jscodeshift": "^0.11.0",
     "react-codemod": "5.4.3"
   }


### PR DESCRIPTION
iceworks-codmod 插件在上一个[版本中发布失败](https://github.com/ice-lab/iceworks/runs/2430359285?check_suite_focus=true)了：

![image](https://user-images.githubusercontent.com/4392234/115984881-c8c97980-a5db-11eb-9c27-bdce45c85d79.png)

原因是 [next-js-codemod](https://www.npmjs.com/package/next-js-codemod) 这个包依赖到了老的 recast (https://github.com/microsoft/vscode-vsce/issues/217)
recast 发了新版本修复了这个问题 (https://github.com/benjamn/recast/issues/449#issuecomment-346456022)

**next-js-codemo 新版删除了对 jscodeshift(->recast) 的依赖。**