### PR TITLE
fix: remove referenced identifiers

### DIFF
--- a/extensions/react-refactor/CHANGELOG.md
+++ b/extensions/react-refactor/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.0.2
+
+- fix: remove referenced identifiers in ArrayPattern and ObjectPattern
+
 ## 1.0.1
 
 - fix .vscodeignore configuration [#576](https://github.com/microsoft/vscode-vsce/issues/576)

--- a/extensions/react-refactor/package.json
+++ b/extensions/react-refactor/package.json
@@ -4,7 +4,7 @@
   "description": "Easily refactor Component in React/Rax.",
   "publisher": "iceworks-team",
   "icon": "assets/logo.png",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "engines": {
     "vscode": "^1.41.0"
   },

--- a/extensions/react-refactor/src/__tests__/suite/index.ts
+++ b/extensions/react-refactor/src/__tests__/suite/index.ts
@@ -46,7 +46,7 @@ class CoverageRunner {
     this.options = options;
   }
 
-  public setupCoverage(): void {
+  setupCoverage(): void {
     // Set up Code Coverage, hooking require so that instrumented code is returned
     const self = this;
     self.instrumenter = new istanbul.Instrumenter({ coverageVariable: self.coverageVar });
@@ -102,7 +102,7 @@ class CoverageRunner {
    *
    * @memberOf CoverageRunner
    */
-  public reportCoverage(): void {
+  reportCoverage(): void {
     const self = this;
     istanbul.hook.unhookRequire();
     let cov: any;
@@ -173,11 +173,11 @@ export function run(): Promise<void> {
       }
 
       // Add files to the test suite
-      files.forEach(f => mocha.addFile(path.resolve(testsRoot, f)));
+      files.forEach((f) => mocha.addFile(path.resolve(testsRoot, f)));
 
       try {
         // Run the mocha test
-        mocha.run(failures => {
+        mocha.run((failures) => {
           if (failures > 0) {
             e(new Error(`${failures} tests failed.`));
           } else {

--- a/extensions/react-refactor/src/refactor/modules/removeUselessReferences.ts
+++ b/extensions/react-refactor/src/refactor/modules/removeUselessReferences.ts
@@ -150,7 +150,26 @@ export function removeUselessReferences(ast: any, originUnrefIdentifiers: string
         }
 
         if (path && path.node) {
-          binding.path.remove();
+          const { id } = path.node as any;
+          if (id && (t.isArrayPattern(id) || t.isObjectPattern(id))) {
+            // const [a, b] = [1, 2]
+            // const { a, b } = obj;
+            const { properties, elements } = id as any;
+            if (properties) {
+              const propertyIndex = properties.findIndex(({ key }) => key.name === name);
+              if (propertyIndex) {
+                properties.splice(propertyIndex, 1);
+              }
+            }
+            if (elements) {
+              const elementIndex = elements.findIndex((item) => item.name === name);
+              if (elementIndex) {
+                elements.splice(elementIndex, 1);
+              }
+            }
+          } else {
+            binding.path.remove();
+          }
         }
       } else {
         // remove identifier in the parent scope

--- a/extensions/react-refactor/src/refactor/utils/handleValidIdentifier.ts
+++ b/extensions/react-refactor/src/refactor/utils/handleValidIdentifier.ts
@@ -1,20 +1,22 @@
 function handleValidIdentifier(identifierPath, callback) {
-  switch (identifierPath.parent.type) {
-    case 'ObjectProperty':
-      if (identifierPath.parent.key !== identifierPath.node) {
-        callback();
-      }
-      break;
-    case 'MemberExpression':
+  if (identifierPath.parent) {
+    switch (identifierPath.parent.type) {
+      case 'ObjectProperty':
+        if (identifierPath.parent.key !== identifierPath.node) {
+          callback();
+        }
+        break;
+      case 'MemberExpression':
       // For list[index]
-      if (identifierPath.parent.computed) {
+        if (identifierPath.parent.computed) {
+          callback();
+        } else if (identifierPath.parent.property !== identifierPath.node) {
+          callback();
+        }
+        break;
+      default:
         callback();
-      } else if (identifierPath.parent.property !== identifierPath.node) {
-        callback();
-      }
-      break;
-    default:
-      callback();
+    }
   }
 }
 

--- a/extensions/react-refactor/src/utils/prettierFormat.ts
+++ b/extensions/react-refactor/src/utils/prettierFormat.ts
@@ -4,7 +4,7 @@ function prettierFormat(code: string) {
   return prettier.format(code, {
     singleQuote: true,
     trailingComma: 'es5',
-    parser: 'babel',
+    parser: 'typescript',
   });
 }
 


### PR DESCRIPTION
### 背景

对于以下两种情况，如果 b 没有被引用，会把整个语句删掉： 
```js
const [a, b] = [1, 2];
const {a, b} = obj;
```

期望是只把 b 删掉就行了